### PR TITLE
Learner dashboard refacto

### DIFF
--- a/actions/CourseMenuAction.php
+++ b/actions/CourseMenuAction.php
@@ -1,13 +1,11 @@
 <?php
 
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Core\YesWikiAction;
 use YesWiki\Lms\Activity;
 use YesWiki\Lms\Controller\CourseController;
 use YesWiki\Lms\Service\CourseManager;
 use YesWiki\Lms\Service\LearnerManager;
-use YesWiki\Wiki;
 
 class CourseMenuAction extends YesWikiAction
 {

--- a/actions/LearnerDashboardAction.php
+++ b/actions/LearnerDashboardAction.php
@@ -2,7 +2,7 @@
 
 use YesWiki\Core\Service\UserManager;
 use YesWiki\Core\YesWikiAction;
-use YesWiki\Lms\Controller\LearnerDashboardController;
+use YesWiki\Lms\Service\LearnerDashboardManager;
 use YesWiki\Lms\Service\CourseManager;
 use YesWiki\Lms\Service\LearnerManager;
 
@@ -11,14 +11,14 @@ class LearnerDashboardAction extends YesWikiAction
     protected $courseManager;
     protected $userManager;
     protected $learnerManager;
-    protected $LearnerDashboardController;
+    protected $learnerDashboardManager;
     protected $learner;
 
     public function run()
     {
         $this->courseManager = $this->getService(CourseManager::class);
         $this->learnerManager = $this->getService(LearnerManager::class);
-        $this->LearnerDashboardController = $this->getService(LearnerDashboardController::class);
+        $this->learnerDashboardManager = $this->getService(LearnerDashboardManager::class);
         $this->userManager = $this->getService(UserManager::class);
 
         // user connected ?
@@ -73,7 +73,7 @@ class LearnerDashboardAction extends YesWikiAction
             $this->wiki->Redirect($this->wiki->Href('', '', $params_temp, false));
         }
 
-        $coursesStat = $this->LearnerDashboardController->processCoursesStat($courses, $this->learner);
+        $coursesStat = $this->learnerDashboardManager->processCoursesStat($courses, $this->learner);
 
         return $this->render('@lms/learner-dashboard.twig', [
             'learner' => $this->learner,

--- a/actions/LearnerDashboardAction.php
+++ b/actions/LearnerDashboardAction.php
@@ -75,6 +75,7 @@ class LearnerDashboardAction extends YesWikiAction
 
         $coursesStat = $this->learnerDashboardManager->processCoursesStat($courses, $this->learner);
 
+        $this->wiki->AddJavascriptFile('tools/lms/presentation/javascript/collapsible-panel.js');
         return $this->render('@lms/learner-dashboard.twig', [
             'learner' => $this->learner,
             'courses' => $courses,

--- a/actions/LearnerDashboardAction.php
+++ b/actions/LearnerDashboardAction.php
@@ -22,7 +22,7 @@ class LearnerDashboardAction extends YesWikiAction
         $this->userManager = $this->getService(UserManager::class);
 
         // user connected ?
-        if ($this->userManager->getLoggedUser() == '') {
+        if (!$this->userManager->getLoggedUser()) {
             // not connected
             return $this->render('@lms/alert-message.twig', [
                 'alertMessage' => _t('LOGGED_USERS_ONLY_ACTION') . ' (learnerdashboard)'

--- a/actions/LearnerDashboardAction.php
+++ b/actions/LearnerDashboardAction.php
@@ -1,84 +1,80 @@
 <?php
 
+use YesWiki\Core\Service\UserManager;
 use YesWiki\Core\YesWikiAction;
 use YesWiki\Lms\Controller\LearnerDashboardController;
 use YesWiki\Lms\Service\CourseManager;
 use YesWiki\Lms\Service\LearnerManager;
-use YesWiki\Core\Service\UserManager;
-use YesWiki\Lms\Learner;
-use YesWiki\Wiki;
 
 class LearnerDashboardAction extends YesWikiAction
 {
-    protected $courseManager ;
+    protected $courseManager;
     protected $userManager;
-    protected $learnerManager ;
-    protected $LearnerDashboardController ;
-    protected $learner ;
-    
+    protected $learnerManager;
+    protected $LearnerDashboardController;
+    protected $learner;
+
     public function run()
     {
         $this->courseManager = $this->getService(CourseManager::class);
         $this->learnerManager = $this->getService(LearnerManager::class);
         $this->LearnerDashboardController = $this->getService(LearnerDashboardController::class);
         $this->userManager = $this->getService(UserManager::class);
+
         // user connected ?
         if ($this->userManager->getLoggedUser() == '') {
             // not connected
             return $this->render('@lms/alert-message.twig', [
-                'alertMessage' => _t('LOGGED_USERS_ONLY_ACTION') . ' “learnerdashboard”'
+                'alertMessage' => _t('LOGGED_USERS_ONLY_ACTION') . ' (learnerdashboard)'
             ]);
         }
         // get user name option only for admins
         if ($this->wiki->UserIsAdmin()) {
-            $learnerNameOption = $this->wiki->GetParameter('learner');
-            $learnerNameOption = (empty($learnerNameOption)) ? ((empty($_REQUEST['learner'])) ? '' : $_REQUEST['learner']) : $learnerNameOption ;
-        } else {
-            $learnerNameOption = '' ;
+            // get the learner parameter from both GET and POST
+            $learnerNameOption = !empty($_REQUEST['learner']) ? $_REQUEST['learner'] : null;
         }
         // get learner
         $this->learner = $this->learnerManager->getLearner($learnerNameOption);
         if (!$this->learner) {
             // not connected
             return $this->render('@lms/alert-message.twig', [
-                'alertMessage' => _t('LOGGED_USERS_ONLY_ACTION') . ' “learnerdashboard”'
+                'alertMessage' => _t('LOGGED_USERS_ONLY_ACTION') . ' (learnerdashboard)'
             ]);
         }
-        if ($this->wiki->UserIsAdmin() &&
-            (empty($this->wiki->GetParameter('selectuser')) || $this->wiki->GetParameter('selectuser') ==  'true') &&
-            empty($learnerNameOption)) {
-            return $this->renderSelectUser() ;
+        if ($this->wiki->UserIsAdmin()
+            && (empty($this->wiki->GetParameter('selectuser')) || $this->wiki->GetParameter('selectuser') == 'true')
+            && empty($learnerNameOption)
+        ) {
+            return $this->renderSelectUser();
         } else {
-            return $this->renderDashboard() ;
+            return $this->renderDashboard();
         }
     }
 
     private function renderDashboard()
     {
-        $courseTag = (isset($_GET['course'])) ? $_GET['course'] : null ;
-        $courseTag = (!$courseTag && isset($_POST['course'])) ? $_POST['course'] : $courseTag ;
+        $courseTag = !empty($_GET['course']) ? $_GET['course'] : null;
+        if ($courseTag) {
+            // restrict to only one course
+            $course = $this->courseManager->getCourse($courseTag);
+            $courses = ($course) ? [$course] : null;
+        }
+        if (!isset($courses)) {
+            // get all courses
+            $courses = $this->courseManager->getAllCourses();
+        }
 
-        if (empty($_GET['learner']) && !empty($_POST['learner'])) {
-            $params_temp = [] ;
-            $params_temp['learner'] = $this->learner->getUsername() ;
+        if (empty($_GET['learner'])) {
+            $params_temp = [];
+            $params_temp['learner'] = $this->learner->getUsername();
             if ($courseTag) {
-                $params_temp['course'] = $courseTag ;
+                $params_temp['course'] = $courseTag;
             }
             $this->wiki->Redirect($this->wiki->Href('', '', $params_temp, false));
         }
 
-        if ($courseTag) {
-            // get one tag
-            $courses = $this->courseManager->getCourse($courseTag) ;
-            $courses = ($courses) ? [$courses] : null ;
-        }
-        if (!isset($courses)) {
-            // get all courses
-            $courses = $this->courseManager->getAllCourses() ;
-        }
-        
-        $coursesStat = $this->LearnerDashboardController->processCoursesStat($courses, $this->learner) ;
-        
+        $coursesStat = $this->LearnerDashboardController->processCoursesStat($courses, $this->learner);
+
         return $this->render('@lms/learner-dashboard.twig', [
             'learner' => $this->learner,
             'courses' => $courses,
@@ -87,6 +83,7 @@ class LearnerDashboardAction extends YesWikiAction
             'use_only_custom_elapsed_time' => $this->wiki->config['lms_config']['use_only_custom_elapsed_time']
         ]);
     }
+
     private function renderSelectUser()
     {
         // check if user is in @admins
@@ -98,15 +95,15 @@ class LearnerDashboardAction extends YesWikiAction
         }
 
         // list user
-        $users = $this->userManager->getAll() ;
+        $users = $this->userManager->getAll();
         $usersList = array_map(function ($user) {
-            $learner = $this->learnerManager->getLearner($user['name']) ;
-            return [ 'tag' => $learner->getUsername() , 'fullname' => $learner->getFullname()] ;
-        }, $users) ;
+            $learner = $this->learnerManager->getLearner($user['name']);
+            return ['tag' => $learner->getUsername(), 'fullname' => $learner->getFullname()];
+        }, $users);
 
         // propose form with select
         return $this->render('@lms/learner-dashboard-select-user.twig', [
             'usersList' => $usersList
-            ]);
+        ]);
     }
 }

--- a/controllers/CourseController.php
+++ b/controllers/CourseController.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use YesWiki\Bazar\Service\EntryManager;
-use YesWiki\Core\Service\TemplateEngine;
 use YesWiki\Core\YesWikiController;
 use YesWiki\Lms\Activity;
 use YesWiki\Lms\Course;

--- a/handlers/ExportDashboardCSVHandler.php
+++ b/handlers/ExportDashboardCSVHandler.php
@@ -4,61 +4,62 @@ use YesWiki\Core\Service\UserManager;
 use YesWiki\Core\YesWikiHandler;
 use YesWiki\Lms\Controller\LearnerDashboardController;
 use YesWiki\Lms\Service\CourseManager;
+use YesWiki\Lms\Service\DateManager;
 use YesWiki\Lms\Service\LearnerManager;
-use YesWiki\Wiki;
 
 class ExportDashboardCSvHandler extends YesWikiHandler
 {
     protected $courseManager;
     protected $userManager;
     protected $learnerManager;
-    protected $LearnerDashboardController;
+    protected $learnerDashboardController;
+    protected $dateManager;
+
     protected $learner;
 
     public function run()
     {
         $this->courseManager = $this->getService(CourseManager::class);
-        $this->learnerManager = $this->getService(LearnerManager::class);
-        $this->LearnerDashboardController = $this->getService(LearnerDashboardController::class);
         $this->userManager = $this->getService(UserManager::class);
+        $this->learnerManager = $this->getService(LearnerManager::class);
+        $this->learnerDashboardController = $this->getService(LearnerDashboardController::class);
+        $this->dateManager = $this->getService(DateManager::class);
+
         // user connected ?
         if ($this->userManager->getLoggedUser() == '') {
             // not connected
-            return $this->renderErrorMSG(_t('LMS_LOGGED_USERS_ONLY_HANDLER') . ' ExportDashboardCSV');
+            return $this->renderErrorMsg(_t('LMS_LOGGED_USERS_ONLY_HANDLER') . ' (exportdashboardcsv)');
         }
         // get user name option only for admins
         if ($this->wiki->UserIsAdmin()) {
-            // get user name option
-            $learnerNameOption = $this->wiki->GetParameter('learner');
-            $learnerNameOption = (empty($learnerNameOption)) ? ((empty($_REQUEST['learner'])) ? '' : $_REQUEST['learner']) : $learnerNameOption;
-        } else {
-            $learnerNameOption = '';
+            // get the learner parameter only from GET
+            $learnerNameOption = !empty($_GET['learner']) ? $_GET['learner'] : null;
         }
         // get learner
         $this->learner = $this->learnerManager->getLearner($learnerNameOption);
         if (!$this->learner) {
             // not connected
-            return $this->renderErrorMSG(_t('LMS_LOGGED_USERS_ONLY_HANDLER') . ' ExportDashboardCSV');
+            return $this->renderErrorMsg(_t('LMS_LOGGED_USERS_ONLY_HANDLER') . ' (exportdashboardcsv)');
         }
-        return $this->exportToCSV();
-    }
-
-
-    public function exportToCSV(): string
-    {
-        $courseTag = (isset($_GET['course'])) ? $_GET['course'] : null;
-        $courseTag = (!$courseTag && isset($_POST['course'])) ? $_POST['course'] : $courseTag;
-
+        // get course
+        $courseTag = !empty($_GET['course']) ? $_GET['course'] : null;
         if ($courseTag) {
-            // get one tag
-            $courses = $this->courseManager->getCourse($courseTag);
-            $courses = ($courses) ? [$courses] : null;
+            // restrict to only one course
+            $course = $this->courseManager->getCourse($courseTag);
+            $courses = $course ? [$course] : null;
         }
         if (!isset($courses)) {
             // get all courses
             $courses = $this->courseManager->getAllCourses();
         }
-        $coursesStat = $this->LearnerDashboardController->processCoursesStat($courses, $this->learner);
+
+        $this->exportToCSV($courses);
+        return '';
+    }
+
+    public function exportToCSV(array $courses)
+    {
+        $coursesStat = $this->learnerDashboardController->processCoursesStat($courses, $this->learner);
 
         // output headers so that the file is downloaded rather than displayed
         header('Content-Type: text/csv; charset=utf-8');
@@ -87,7 +88,7 @@ class ExportDashboardCSvHandler extends YesWikiHandler
                 $progressRatio = $courseStat['progressRatio'] . ' %';
             }
             $elapsedTime = ($courseStat['elapsedTime']) ?
-                $courseStat['elapsedTime']->format('%h h %I min.') : null;
+                $this->dateManager->formatDateWithColons($courseStat['elapsedTime']) : null;
             $row = [
                 _t('LMS_DASHBOARD_COURSE') . ' ' . $courseIndex,
                 $course->getTitle(),
@@ -105,9 +106,12 @@ class ExportDashboardCSvHandler extends YesWikiHandler
                 } else {
                     $progressRatio = $moduleStat['progressRatio'] . ' %';
                 }
-                $elapsedTime = ($moduleStat['elapsedTime'] &&
-                    !($this->wiki->config['lms_config']['use_only_custom_elapsed_time'] && !$moduleStat['finished'])) ?
-                    $moduleStat['elapsedTime']->format('%h h %I min.') : null;
+                $elapsedTime = ($moduleStat['elapsedTime']
+                    && !($this->wiki->config['lms_config']['use_only_custom_elapsed_time']
+                        && !$moduleStat['finished'])
+                ) ?
+                    $this->dateManager->formatDateWithColons($moduleStat['elapsedTime'])
+                    : null;
                 $row = [
                     _t('LMS_DASHBOARD_MODULE') . ' ' . $courseIndex . '.' . $moduleIndex,
                     $module->getTitle(),
@@ -125,9 +129,10 @@ class ExportDashboardCSvHandler extends YesWikiHandler
                     } else {
                         $progressRatio = '----';
                     }
-                    $elapsedTime = ($this->wiki->config['lms_config']['display_activity_elapsed_time'] &&
-                        $activityStat['elapsedTime'] && $activityStat['finished']) ?
-                        $activityStat['elapsedTime']->format('%h h %I min.') : null;
+                    $elapsedTime = ($this->wiki->config['lms_config']['display_activity_elapsed_time']
+                        && $activityStat['elapsedTime'] && $activityStat['finished']) ?
+                        $this->dateManager->formatDateWithColons($activityStat['elapsedTime'])
+                        : null;
                     $row = [
                         _t('LMS_ACTIVITY') . ' ' . $courseIndex . '.' . $moduleIndex . '.' . $activityIndex,
                         $activity->getTitle(),
@@ -139,11 +144,9 @@ class ExportDashboardCSvHandler extends YesWikiHandler
                 }
             }
         }
-
-        return '';
     }
 
-    private function renderErrorMSG(string $errorMessage): string
+    private function renderErrorMsg(string $errorMessage): string
     {
         $output = $this->wiki->header();
         $output .= $this->render('@lms/alert-message.twig', [

--- a/handlers/ExportDashboardCSVHandler.php
+++ b/handlers/ExportDashboardCSVHandler.php
@@ -2,7 +2,7 @@
 
 use YesWiki\Core\Service\UserManager;
 use YesWiki\Core\YesWikiHandler;
-use YesWiki\Lms\Controller\LearnerDashboardController;
+use YesWiki\Lms\Service\LearnerDashboardManager;
 use YesWiki\Lms\Service\CourseManager;
 use YesWiki\Lms\Service\DateManager;
 use YesWiki\Lms\Service\LearnerManager;
@@ -12,7 +12,7 @@ class ExportDashboardCSvHandler extends YesWikiHandler
     protected $courseManager;
     protected $userManager;
     protected $learnerManager;
-    protected $learnerDashboardController;
+    protected $learnerDashboardManager;
     protected $dateManager;
 
     protected $learner;
@@ -22,7 +22,7 @@ class ExportDashboardCSvHandler extends YesWikiHandler
         $this->courseManager = $this->getService(CourseManager::class);
         $this->userManager = $this->getService(UserManager::class);
         $this->learnerManager = $this->getService(LearnerManager::class);
-        $this->learnerDashboardController = $this->getService(LearnerDashboardController::class);
+        $this->learnerDashboardManager = $this->getService(LearnerDashboardManager::class);
         $this->dateManager = $this->getService(DateManager::class);
 
         // user connected ?
@@ -59,7 +59,7 @@ class ExportDashboardCSvHandler extends YesWikiHandler
 
     public function exportToCSV(array $courses)
     {
-        $coursesStat = $this->learnerDashboardController->processCoursesStat($courses, $this->learner);
+        $coursesStat = $this->learnerDashboardManager->processCoursesStat($courses, $this->learner);
 
         // output headers so that the file is downloaded rather than displayed
         header('Content-Type: text/csv; charset=utf-8');

--- a/handlers/UpdateElapsedTimeHandler.php
+++ b/handlers/UpdateElapsedTimeHandler.php
@@ -1,202 +1,174 @@
 <?php
 
-use YesWiki\Core\YesWikiHandler;
+use Carbon\CarbonInterval;
 use YesWiki\Core\Service\UserManager;
-use YesWiki\Lms\Controller\LearnerDashboardController;
-use YesWiki\Lms\Service\CourseManager;
-use YesWiki\Lms\Service\LearnerManager;
+use YesWiki\Core\YesWikiHandler;
 use YesWiki\Lms\Activity;
+use YesWiki\Lms\Controller\LearnerDashboardController;
 use YesWiki\Lms\Course;
 use YesWiki\Lms\Learner;
 use YesWiki\Lms\Module;
-use YesWiki\Wiki;
+use YesWiki\Lms\Service\CourseManager;
+use YesWiki\Lms\Service\DateManager;
+use YesWiki\Lms\Service\LearnerManager;
 
 class UpdateElapsedTimeHandler extends YesWikiHandler
 {
     protected $userManager;
     protected $courseManager;
-    protected $learnerManager ;
-    protected $LearnerDashboardController ;
+    protected $learnerManager;
+    protected $learnerDashboardController;
+    protected $dateManager;
 
     public function run()
     {
         $this->userManager = $this->getService(UserManager::class);
         $this->courseManager = $this->getService(CourseManager::class);
         $this->learnerManager = $this->getService(LearnerManager::class);
-        $this->LearnerDashboardController = $this->getService(LearnerDashboardController::class);
-        // check if connected
-        if ($this->userManager->getLoggedUser() == '') {
+        $this->learnerDashboardController = $this->getService(LearnerDashboardController::class);
+        $this->dateManager = $this->getService(DateManager::class);
+
+        // user connected ?
+        if (!$this->userManager->getLoggedUser()) {
             // not connected
-            return $this->renderErrorMSG(_t('LMS_LOGGED_USERS_ONLY_HANDLER') . ' UpdateElapsedTime') ;
+            return $this->renderErrorMsg(_t('LMS_LOGGED_USERS_ONLY_HANDLER') . ' UpdateElapsedTime');
         }
-        // check validity for user
-        $learnerName = '' ;
-        if (isset($_GET['learner']) || isset($_POST['learner'])) {
-            if ($this->wiki->UserIsAdmin()) {
-                $learnerName = (isset($_GET['learner'])) ? $_GET['learner'] :
-                    ((isset($_POST['learner'])) ? $_POST['learner'] : '') ;
-                if (empty($this->userManager->getOneByName($learnerName))) {
-                    return $this->renderErrorMSG('In params, the user "'.$learnerName.'" does not exist !') ;
-                }
+        // check validity for user (only for admins)
+        $learnerName = null;
+        if (isset($_GET['learner']) && $this->wiki->UserIsAdmin()) {
+            $learnerName = isset($_GET['learner']) ? $_GET['learner'] : null;
+            if (empty($this->userManager->getOneByName($learnerName))) {
+                return $this->renderErrorMsg('In params, the user \'' . $learnerName . '\' does not exist !');
             }
         }
-        // get Learner
-        $learner = $this->learnerManager->getLearner($learnerName) ;
+        // get learner (if null, set elapsed time for current learner)
+        $learner = $this->learnerManager->getLearner($learnerName);
         // get course
-        if (isset($_GET['course']) || isset($_POST['course'])) {
-            $courseTag = (isset($_GET['course'])) ? $_GET['course'] :
-                ((isset($_POST['course'])) ? $_POST['course'] : '') ;
-            $course = $this->courseManager->getCourse($courseTag) ;
+        if (!empty($_GET['course'])) {
+            $courseTag = $_GET['course'];
+            $course = $this->courseManager->getCourse($courseTag);
             if (!$course) {
-                return $this->renderErrorMSG('In params, the course "'.$courseTag.'" is not a course!') ;
+                return $this->renderErrorMsg('In params, the course \'' . $courseTag . '\' is not a course !');
             }
         } else {
-            return $this->renderErrorMSG('The parameter "course" is required !') ;
+            return $this->renderErrorMsg('The parameter \'course\' is required !');
         }
         // get module
-        if (isset($_GET['module']) || isset($_POST['module'])) {
-            $moduleTag = (isset($_GET['module'])) ? $_GET['module'] :
-                ((isset($_POST['module'])) ? $_POST['module'] : '') ;
-            $module = $this->courseManager->getModule($moduleTag) ;
+        if (!empty($_GET['module'])) {
+            $moduleTag = $_GET['module'];
+            $module = $this->courseManager->getModule($moduleTag);
             if (!$module) {
-                return $this->renderErrorMSG('In params, the module "'.$moduleTag.'" is not a module!') ;
+                return $this->renderErrorMsg('In params, the module \'' . $moduleTag . '\' is not a module !');
             }
             if (!$course->hasModule($moduleTag)) {
-                return $this->renderErrorMSG('In params, the module "'.$moduleTag.
-                    '" is a module but not a module of course "'.$courseTag.'"!') ;
+                return $this->renderErrorMsg('In params, the module \'' . $moduleTag .
+                    '\' is a module but not a module of course \'' . $courseTag . '\' !');
             }
         } else {
-            return $this->renderErrorMSG('The parameter "module" is required !') ;
+            return $this->renderErrorMsg('The parameter \'module\' is required !');
         }
         // get activity
-        if (isset($_GET['activity']) || isset($_POST['activity'])) {
-            $activityTag = (isset($_GET['activity'])) ? $_GET['activity'] :
-                ((isset($_POST['activity'])) ? $_POST['activity'] : '') ;
-            $activity = $this->courseManager->getActivity($activityTag) ;
+        if (!empty($_GET['activity'])) {
+            $activityTag = $_GET['activity'];
+            $activity = $this->courseManager->getActivity($activityTag);
             if (!$activity) {
-                return $this->renderErrorMSG('In params, the activity "'.$activityTag.'" is not an activity!') ;
+                return $this->renderErrorMsg('In params, the activity \'' . $activityTag . '\' is not an activity !');
             }
             if (!$module->hasActivity($activityTag)) {
-                return $this->renderErrorMSG('In params, the activity "'.$activityTag.
-                    '" is an activity but not an activity of module "'.$moduleTag.'"!') ;
+                return $this->renderErrorMsg('In params, the activity \'' . $activityTag .
+                    '\' is an activity but not an activity of module \'' . $moduleTag . '\' !');
             }
         } else {
-            $activity = null ;
+            $activity = null;
+        }
+        // check if the needed parameters are defined
+        if (!$learner || !$course || !$module){
+            return $this->renderErrorMsg('The GET parameters \'learner\', \'course\' and \'module\' need to be defined !');
         }
 
-        // check if parameters
-        if (isset($_REQUEST['elapsedtime'])) {
+        if (isset($_POST['elapsedtime'])) {
             // update mode
-            return $this->renderUpdate($learner, $course, $module, $activity) ;
+            return $this->renderUpdate($learner, $course, $module, $activity);
         }
         // render form to ask new value
-        return $this->renderForm($learner, $course, $module, $activity) ;
+        return $this->renderForm($learner, $course, $module, $activity);
     }
 
     private function renderUpdate(Learner $learner, Course $course, Module $module, ?Activity $activity): string
     {
-        
         // get elapsedtime
-        if (isset($_GET['elapsedtime']) || isset($_POST['elapsedtime'])) {
-            $elapsedtime = (isset($_GET['elapsedtime'])) ? $_GET['elapsedtime'] :
-                ((isset($_POST['elapsedtime'])) ? $_POST['elapsedtime'] : '') ;
-            $elapsedtime = intval($elapsedtime) ;
-            if ($elapsedtime <0) {
-                return $this->renderErrorMSG('The parameters "elapsedtime" must be positive.') ;
+        if (isset($_POST['elapsedtime'])) {
+            if (!ctype_digit($_POST['elapsedtime'])) {
+                return $this->renderErrorMsg('The GET parameter \'elapsedtime\' must be a positive integer');
             }
-            $elapsed_time = (new \DateTime())->setTimestamp(0)->diff(
-                (new \DateTime())->setTimestamp(0)->add(new \DateInterval('PT'.$elapsedtime.'M'))
-            );
-            if ($elapsed_time === false) {
-                return $this->renderErrorMSG('Error when importing "elapsedtime" parameter !') ;
-            }
+            $elapsedTime = $this->dateManager->createIntervalFromMinutes(intval($_POST['elapsedtime']));
         } else {
-            return $this->renderErrorMSG('The parameter "elapsedtime" is required !') ;
+            return $this->renderErrorMsg('The parameter \'elapsedtime\' is required !');
         }
         // update value
-        if ($elapsed_time->i == 0 && $elapsed_time->h == 0 && $elapsed_time->s == 0
-            && $elapsed_time->d == 0 && $elapsed_time->m == 0 && $elapsed_time->y == 0) {
+        if ($elapsedTime->totalMinutes == 0) {
             // reset elapsed time
-            $updateResult = $learner->resetElapsedTime(
-                $course,
-                $module,
-                $activity
-            );
+            $updateResult = $learner->resetElapsedTime($course, $module, $activity);
         } else {
-            $updateResult = $learner->saveElapsedTime(
-                $course,
-                $module,
-                $activity,
-                $elapsed_time
-            );
+            $updateResult = $learner->saveElapsedTime($course, $module, $activity, $elapsedTime);
         }
         if (!$updateResult) {
-            return $this->renderErrorMSG('The update of elapsed time for course "'.$course->getTag() .
-                '", module "'.$module->getTag().'", '. (!empty($activity) ? 'activity "'.$activity->getTag(). '"': '') .
-                ' and elapsed time "'.$elapsedtime.'" minutes has not worked !') ;
+            return $this->renderErrorMsg('The update of elapsed time for course \'' . $course->getTag() .
+                '\', module \'' . $module->getTag() . '\', ' . (!empty($activity) ? 'activity \'' . $activity->getTag() . '\'' : '') .
+                ' and elapsed time \'' . $elapsedTime . '\' minutes has not worked !');
         }
         // redirect to page
         $this->wiki->Redirect($this->wiki->Href('', '', $this->extractPreviousParams(), false));
-        return $this->renderErrorMSG('There was a trouble with redirect in renderUpdate() for UpdateElapsedTimeHandler !') ;
+        return $this->renderErrorMsg('There was a trouble with redirect in renderUpdate() for UpdateElapsedTimeHandler !');
     }
 
     private function renderForm(Learner $learner, Course $course, Module $module, ?Activity $activity): string
     {
         // get all courses
-        $courses = $this->courseManager->getAllCourses() ;
-        $coursesStat = $this->LearnerDashboardController->processCoursesStat($courses, $learner) ;
+        $courses = $this->courseManager->getAllCourses();
+        $coursesStat = $this->learnerDashboardController->processCoursesStat($courses, $learner);
 
-        $output = $this->wiki->header() ;
-        $previousparams = $this->extractPreviousParams() ;
+        $output = $this->wiki->header();
+        $previousparams = $this->extractPreviousParams();
         $output .= $this->render('@lms/learner-update-elapsed-time.twig', [
-                'learner' => $learner,
-                'course' => $course,
-                'module' => $module,
-                'activity' => $activity,
-                'previousparamskeys' => ($previousparams) ? implode(',', array_keys($previousparams)) : '',
-                'previousparams' => $previousparams,
-                'tag' => $this->wiki->GetPageTag(),
-                'coursesStat' => $coursesStat
-            ]);
-        $output .= $this->wiki->footer() ;
-        return $output ;
+            'learner' => $learner,
+            'course' => $course,
+            'module' => $module,
+            'activity' => $activity,
+            'previousparams' => $previousparams,
+            'tag' => $this->wiki->GetPageTag(),
+            'coursesStat' => $coursesStat
+        ]);
+        $output .= $this->wiki->footer();
+        return $output;
     }
 
-    private function renderErrorMSG(string $errorMessage): string
+    private function renderErrorMsg(string $errorMessage): string
     {
-        $output = $this->wiki->header() ;
+        $output = $this->wiki->header();
         $output .= $this->render('@lms/alert-message.twig', [
-                'alertMessage' => $errorMessage
-            ]);
+            'alertMessage' => $errorMessage
+        ]);
         $output .= $this->render('@lms/return-button.twig', [
-                'tag' => $this->wiki->GetPageTag(),
-                'params' => $this->extractPreviousParams()
-            ]);
-        $output .= $this->wiki->footer() ;
-        return $output ;
+            'tag' => $this->wiki->GetPageTag(),
+            'params' => $this->extractPreviousParams()
+        ]);
+        $output .= $this->wiki->footer();
+        return $output;
     }
 
-    private function extractPreviousParams(): ?array
+    private function extractPreviousParams(): array
     {
-        if (isset($_REQUEST['previousparams'])) {
-            $previousparams = (isset($_GET['previousparams'])) ?  explode(',', $_GET['previousparams']) :
-                ((isset($_POST['previousparams'])) ? explode(',', $_POST['previousparams']) : null) ;
-            if ($previousparams && is_array($previousparams)) {
-                $params = [] ;
+        if (isset($_GET['previousparams'])) {
+            $previousparams = explode(',', $_GET['previousparams']);
+            if ($previousparams) {
+                $params = [];
                 foreach ($previousparams as $paramName) {
-                    if (isset($_GET[$paramName])) {
-                        $params[$paramName] = $_GET[$paramName] ;
-                    } elseif (isset($_POST[$paramName])) {
-                        $params[$paramName] = $_POST[$paramName] ;
-                    }
+                    $params[$paramName] = $_GET[$paramName];
                 }
-                $params =  (count($params) == 0) ? null : $params ;
-            } else {
-                $params = null ;
+                return $params;
             }
-        } else {
-            $params = null ;
         }
-        return $params ;
+        return [];
     }
 }

--- a/handlers/UpdateElapsedTimeHandler.php
+++ b/handlers/UpdateElapsedTimeHandler.php
@@ -4,7 +4,7 @@ use Carbon\CarbonInterval;
 use YesWiki\Core\Service\UserManager;
 use YesWiki\Core\YesWikiHandler;
 use YesWiki\Lms\Activity;
-use YesWiki\Lms\Controller\LearnerDashboardController;
+use YesWiki\Lms\Service\LearnerDashboardManager;
 use YesWiki\Lms\Course;
 use YesWiki\Lms\Learner;
 use YesWiki\Lms\Module;
@@ -17,7 +17,7 @@ class UpdateElapsedTimeHandler extends YesWikiHandler
     protected $userManager;
     protected $courseManager;
     protected $learnerManager;
-    protected $learnerDashboardController;
+    protected $learnerDashboardManager;
     protected $dateManager;
 
     public function run()
@@ -25,7 +25,7 @@ class UpdateElapsedTimeHandler extends YesWikiHandler
         $this->userManager = $this->getService(UserManager::class);
         $this->courseManager = $this->getService(CourseManager::class);
         $this->learnerManager = $this->getService(LearnerManager::class);
-        $this->learnerDashboardController = $this->getService(LearnerDashboardController::class);
+        $this->learnerDashboardManager = $this->getService(LearnerDashboardManager::class);
         $this->dateManager = $this->getService(DateManager::class);
 
         // user connected ?
@@ -126,7 +126,7 @@ class UpdateElapsedTimeHandler extends YesWikiHandler
     {
         // get all courses
         $courses = $this->courseManager->getAllCourses();
-        $coursesStat = $this->learnerDashboardController->processCoursesStat($courses, $learner);
+        $coursesStat = $this->learnerDashboardManager->processCoursesStat($courses, $learner);
 
         $output = $this->wiki->header();
         $previousparams = $this->extractPreviousParams();

--- a/libs/Activity.php
+++ b/libs/Activity.php
@@ -2,6 +2,9 @@
 
 namespace YesWiki\Lms;
 
+use Carbon\Carbon;
+use Carbon\CarbonInterval;
+use \DateInterval;
 use YesWiki\Lms\CourseStructure;
 
 class Activity extends CourseStructure

--- a/libs/Learner.php
+++ b/libs/Learner.php
@@ -180,14 +180,16 @@ class Learner
                     ['elapsed_time' => $time->format('%H:%I:%S')]
                 );
             }
-            return $this->tripleStore->update(
+            $update = $this->tripleStore->update(
                 $this->getUsername(),
                 'https://yeswiki.net/vocabulary/progress',
                 $oldValueJson,
                 json_encode($newvalue),
                 '',
                 ''
-            ) == 0;
+            );
+            // 0 when update is correctly done or 3 when the newValue is the same than oldValue (no update)
+            return $update == 0 || $update == 3;
         }
         return false;
     }

--- a/libs/Learner.php
+++ b/libs/Learner.php
@@ -3,6 +3,7 @@
 namespace YesWiki\lms;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterval;
 use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Core\Service\TripleStore;
 use YesWiki\Wiki;
@@ -145,12 +146,12 @@ class Learner
                 ''
             ) == 0;
         if ($resultState) {
-            $this->allProgresses = null; // because Progresses are not upto date
+            $this->allProgresses = null; // because Progresses are not up to date
         }
         return $resultState;
     }
 
-    public function saveElapsedTime(Course $course, Module $module, ?Activity $activity, \DateInterval $time): bool
+    public function saveElapsedTime(Course $course, Module $module, ?Activity $activity, ?CarbonInterval $time): bool
     {
         $like = '%"course":"' . $course->getTag() . '","module":"' . $module->getTag() . '"' .
             (($activity) ? ',"activity":"' . $activity->getTag() . '"' : ',"log_time"')
@@ -163,98 +164,36 @@ class Learner
             '=',
             'LIKE'
         );
-        if (count($results) == 0) {
-            return false;
-        }
-        foreach ($results as $result) {
-            $oldvalueJSON = $result['value'];
-            $oldvalue = json_decode($oldvalueJSON, true);
-            if ($oldvalue['course'] == $course->getTag() &&
-                $oldvalue['module'] == $module->getTag() &&
-                (($activity && isset($oldvalue['activity']) && $oldvalue['activity'] == $activity->getTag()) ||
-                    (!$activity && !isset($oldvalue['activity'])))) {
+        if ($result = array_shift($results)){
+            $oldValueJson = $result['value'];
+            $oldvalue = json_decode($oldValueJson, true);
+            if ($time == null){
+                // if time is null, reset the elapsed_time attribute
+                if (isset($oldvalue['elapsed_time'])) {
+                    unset($oldvalue['elapsed_time']);
+                }
+                $newvalue = $oldvalue;
+            } else {
+                // otherwise, update it
                 $newvalue = array_merge(
                     $oldvalue,
                     ['elapsed_time' => $time->format('%H:%I:%S')]
                 );
-
-                $newvalueJSON = json_encode($newvalue);
-                $updateResult = $this->tripleStore->update(
-                    $this->getUsername(),
-                    'https://yeswiki.net/vocabulary/progress',
-                    $oldvalueJSON,
-                    $newvalueJSON,
-                    '',
-                    ''
-                );
-                // TODO find why we must use twice update function
-                if ($updateResult == 0) {
-                    $updateResult = $this->tripleStore->update(
-                        $this->getUsername(),
-                        'https://yeswiki.net/vocabulary/progress',
-                        $newvalueJSON, // because value is updated
-                        $newvalueJSON,
-                        '',
-                        ''
-                    );
-                }
-                return ($updateResult == 1 || $updateResult == 3);
             }
+            return $this->tripleStore->update(
+                $this->getUsername(),
+                'https://yeswiki.net/vocabulary/progress',
+                $oldValueJson,
+                json_encode($newvalue),
+                '',
+                ''
+            ) == 0;
         }
         return false;
     }
 
     public function resetElapsedTime(Course $course, Module $module, ?Activity $activity): bool
     {
-        $like = '%"course":"' . $course->getTag() . '","module":"' . $module->getTag() . '"' .
-            (($activity) ? ',"activity":"' . $activity->getTag() . '"' : ',"log_time"')
-            . '%'; // if no activity, we are looking for the time attribute just after the module one
-        $results = $this->tripleStore->getMatching(
-            $this->getUsername(),
-            'https://yeswiki.net/vocabulary/progress',
-            $like,
-            '=',
-            '=',
-            'LIKE'
-        );
-        if (count($results) == 0) {
-            return false;
-        }
-        foreach ($results as $result) {
-            $oldvalueJSON = $result['value'];
-            $oldvalue = json_decode($oldvalueJSON, true);
-            if ($oldvalue['course'] == $course->getTag() &&
-                $oldvalue['module'] == $module->getTag() &&
-                (($activity && isset($oldvalue['activity']) && $oldvalue['activity'] == $activity->getTag()) ||
-                    (!$activity && !isset($oldvalue['activity'])))) {
-                if (isset($oldvalue['elapsed_time'])) {
-                    unset($oldvalue['elapsed_time']);
-                }
-                $newvalue = $oldvalue;
-
-                $newvalueJSON = json_encode($newvalue);
-                $updateResult = $this->tripleStore->update(
-                    $this->getUsername(),
-                    'https://yeswiki.net/vocabulary/progress',
-                    $oldvalueJSON,
-                    $newvalueJSON,
-                    '',
-                    ''
-                );
-                // TODO find why we must use twice update function
-                if ($updateResult == 0) {
-                    $updateResult = $this->tripleStore->update(
-                        $this->getUsername(),
-                        'https://yeswiki.net/vocabulary/progress',
-                        $newvalueJSON, // because value is updated
-                        $newvalueJSON,
-                        '',
-                        ''
-                    );
-                }
-                return ($updateResult == 1 || $updateResult == 3);
-            }
-        }
-        return false;
+        return $this->saveElapsedTime($course, $module, $activity, null);
     }
 }

--- a/services/DateManager.php
+++ b/services/DateManager.php
@@ -6,9 +6,8 @@ namespace YesWiki\Lms\Service;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
-use Carbon\Exceptions\ParseErrorException;
+use Exception;
 use YesWiki\Wiki;
-use \Exception;
 
 class DateManager
 {
@@ -27,7 +26,7 @@ class DateManager
     {
         $date = Carbon::createFromFormat('Y-m-d H:i:s', $dateStr);
         // TODO manage the timezone
-        if (!$date){
+        if (!$date) {
             //error_log("Error by parsing the date. The format 'Y-m-d H:i:s' is expected but '$dateStr' is given");
             return null;
         }
@@ -50,8 +49,14 @@ class DateManager
         }
     }
 
-    public function formatDateWithColons(CarbonInterval $duration): string
+    public function formatTimeWithColons(CarbonInterval $duration): string
     {
         return $duration->format('%H:%I:%S');
     }
+
+    public function formatDateWithWrittenMonth(Carbon $date): string
+    {
+        return $date->locale($GLOBALS['prefered_language'])->isoFormat('LLLL');
+    }
+
 }

--- a/services/DateManager.php
+++ b/services/DateManager.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace YesWiki\Lms\Service;
+
+
+use Carbon\Carbon;
+use Carbon\CarbonInterval;
+use Carbon\Exceptions\ParseErrorException;
+use YesWiki\Wiki;
+use \Exception;
+
+class DateManager
+{
+    protected $config;
+
+    /**
+     * DateManager constructor
+     * @param Wiki $wiki the injected Wiki instance
+     */
+    public function __construct(Wiki $wiki)
+    {
+        $this->config = $wiki->config;
+    }
+
+    public function createDateFromString(string $dateStr): ?Carbon
+    {
+        $date = Carbon::createFromFormat('Y-m-d H:i:s', $dateStr);
+        // TODO manage the timezone
+        if (!$date){
+            //error_log("Error by parsing the date. The format 'Y-m-d H:i:s' is expected but '$dateStr' is given");
+            return null;
+        }
+        $date->locale($GLOBALS['prefered_language']);
+        return $date;
+    }
+
+    public function createIntervalFromMinutes(int $minutes): CarbonInterval
+    {
+        return CarbonInterval::minutes($minutes)->cascade();
+    }
+
+    public function createIntervalFromString(string $durationString): ?CarbonInterval
+    {
+        try {
+            return CarbonInterval::createFromFormat('H:i:s', $durationString);
+        } catch (Exception $e) {
+            //error_log("Error by parsing the interval. The format '00:00:00' is expected but '$durationString' is given");
+            return null;
+        }
+    }
+
+    public function formatDateWithColons(CarbonInterval $duration): string
+    {
+        return $duration->format('%H:%I:%S');
+    }
+}

--- a/services/LearnerDashboardManager.php
+++ b/services/LearnerDashboardManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace YesWiki\Lms\Controller;
+namespace YesWiki\Lms\Service;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
@@ -12,24 +12,29 @@ use YesWiki\Lms\Module;
 use YesWiki\Lms\Progresses;
 use YesWiki\Lms\Service\CourseManager;
 use YesWiki\Lms\Service\DateManager;
+use YesWiki\Wiki;
 
-class LearnerDashboardController extends YesWikiController
+class LearnerDashboardManager
 {
+    protected $wiki;
     protected $userManager;
     protected $courseManager;
     protected $dateManager;
 
     /**
-     * LearnerDashboardController constructor
+     * LearnerDashboardManager constructor
+     * @param Wiki $wiki the injected Wiki instance
      * @param UserManager $userManager the injected UserManager instance
      * @param CourseManager $courseManager the injected CourseManager instance
      * @param DateManager $dateManager the injected DateManager instance
      */
     public function __construct(
+        Wiki $wiki,
         UserManager $userManager,
         CourseManager $courseManager,
         DateManager $dateManager
     ) {
+        $this->wiki = $wiki;
         $this->userManager = $userManager;
         $this->courseManager = $courseManager;
         $this->dateManager = $dateManager;

--- a/templates/datetime-macros.twig
+++ b/templates/datetime-macros.twig
@@ -1,0 +1,13 @@
+{% macro displayTime(dateInterval) %}
+    {% if dateInterval is null %}
+        -
+    {% elseif dateInterval.h > 0 or dateInterval.d > 0 or dateInterval.i > 60 %}
+        {{ dateInterval.format('%hh%I') }}
+    {% else %}
+        {{ dateInterval.format('%i min') }}
+    {% endif %}
+{% endmacro %}
+
+{% macro displayDate(dateTime) %}
+    {{ dateTime.isoFormat('LLLL') }}
+{% endmacro %}

--- a/templates/learner-dashboard-activity.twig
+++ b/templates/learner-dashboard-activity.twig
@@ -1,4 +1,4 @@
-{% from "@lms/learner-dashboard.twig" import displayTime,displayDate %}
+{% from "@lms/datetime-macros.twig" import displayTime %}
 <div class="panel panel-lms-dashboard panel-heading dashboard-activity-frame">
   <div class="panel-title">
     {{ activity.title }}
@@ -43,5 +43,6 @@
       </span> 
     </div>
   {% endif %}
-  {{ displayDate(activitiesStat[activity.tag].firstAccessDate)}}
+  {% set dateTime = activitiesStat[activity.tag].firstAccessDate %}
+  {{ include('@lms/learner-dashboard-date.twig') }}
 </div>

--- a/templates/learner-dashboard-activity.twig
+++ b/templates/learner-dashboard-activity.twig
@@ -33,12 +33,11 @@
           {% else %}
               ----
           {% endif %}
-          <a class="btn btn-xs btn-default" 
+          <a class="btn btn-xs btn-default no-collapsable"
               href="{{ url({tag:'',
                             handler:'UpdateElapsedTime',
                             params:{learner:learner.username,course:course.tag,module:module.tag,activity:activity.tag,previousparams:previousparamskeys}}) }}" 
-              title="{{ _t('LMS_UPDATE_ELAPSED_TIME_UPDATE') }}" 
-              onclick="window.location = this.href;">
+              title="{{ _t('LMS_UPDATE_ELAPSED_TIME_UPDATE') }}">
           <i class="fa fa-edit"></i></a>
       </span> 
     </div>

--- a/templates/learner-dashboard-date.twig
+++ b/templates/learner-dashboard-date.twig
@@ -1,0 +1,9 @@
+{% from "@lms/datetime-macros.twig" import displayDate %}
+{% if dateTime %}
+    <div class="first-access">
+        <span title="{{ _t('LMS_DASHBOARD_FIRSTACCESS') }}">
+            <span class="label-icon"><i class="fas fa-calendar-alt"></i></span>
+            {{ displayDate(dateTime) }}
+        </span>
+    </div>
+{% endif %}

--- a/templates/learner-dashboard-module.twig
+++ b/templates/learner-dashboard-module.twig
@@ -1,4 +1,4 @@
-{% from "@lms/learner-dashboard.twig" import displayTime,displayDate %}
+{% from "@lms/datetime-macros.twig" import displayTime %}
 <div class="panel panel-lms-dashboard dashboard-module-frame collapsed">
     <div id="heading_{{ course.tag ~ '_' ~ module.tag }}" class="panel-heading collapsed" role="tab button" data-toggle="collapse"
          href="#collapse_{{ course.tag ~ '_' ~ module.tag }}" aria-expanded="false" aria-controls="collapse_{{ course.tag ~ '_' ~ module.tag }}">
@@ -46,11 +46,12 @@
             </span> 
             </div>
         {% endif %}
-        {{ displayDate(modulesStat[module.tag].firstAccessDate)}}
+        {% set dateTime = modulesStat[module.tag].firstAccessDate %}
+        {{ include('@lms/learner-dashboard-date.twig') }}
     </div>
     <div id="collapse_{{ course.tag ~ '_' ~ module.tag }}" class="panel-collapse collapse" role="tabpanel"
          aria-labelledby="heading_{{ course.tag ~ '_' ~ module.tag }}" aria-expanded="false">
-        <div class="">
+        <div>
             <h4 class="dashboard-module">{{ module.activities|length == 0 ?  _t('LMS_NO_ACTIVITY')  : _t('LMS_ACTIVITIES')}}</h3>
             {% for activity in module.activities %}
                 {% set activitiesStat =  modulesStat[module.tag].activitiesStat %}

--- a/templates/learner-dashboard-module.twig
+++ b/templates/learner-dashboard-module.twig
@@ -36,12 +36,11 @@
                 {% else %}
                     ----
                 {% endif %}
-                <a class="btn btn-xs btn-default" 
+                <a class="btn btn-xs btn-default no-collapsable"
                    href="{{ url({tag:'',
                                  handler:'UpdateElapsedTime',
-                                 params:{learner:learner.username,course:course.tag,module:module.tag,previousparams:previousparamskeys}}) }}" 
-                   title="{{ _t('LMS_UPDATE_ELAPSED_TIME_UPDATE') }}" 
-                   onclick="window.location = this.href;">
+                                 params:{learner: learner.username, course: course.tag, module: module.tag, previousparams: previousparamskeys}}) }}"
+                   title="{{ _t('LMS_UPDATE_ELAPSED_TIME_UPDATE') }}">
                 <i class="fa fa-edit"></i></a>
             </span> 
             </div>

--- a/templates/learner-dashboard.twig
+++ b/templates/learner-dashboard.twig
@@ -6,7 +6,7 @@
   {% set courseTag = '' %}
   {% set previousparamskeys = 'learner' %}
 {% endif %}
-<a href="{{ url({tag:'',handler:'ExportDashboardCSv',params:{learner:learner.username,course:courseTag}}) }}" class="btn btn-primary pull-right">
+<a href="{{ url({tag: '', handler: 'ExportDashboardCsv', params:{learner: learner.username, course: courseTag}}) }}" class="btn btn-primary pull-right">
 <i class="fas fa-download"></i>{{ _t('LMS_DASHBOARD_EXPORT_TO_CSV') }}</a>
 <h1 class="dashboard-title">{{ _t('LMS_DASHBOARD') }}{{ learner.fullname }}</h1>
 

--- a/templates/learner-dashboard.twig
+++ b/templates/learner-dashboard.twig
@@ -1,3 +1,4 @@
+{% from "@lms/datetime-macros.twig" import displayTime %}
 {% if courses|length == 1 %}
   {% set courseTag = (courses|first).tag %}
   {% set previousparamskeys = 'learner,course' %}
@@ -32,11 +33,12 @@
         <div class="estimated-time">
           <span title="{{ _t('LMS_DASHBOARD_ELAPSEDTIME') }}">
             <span class="label-icon"><i class="fas fa-hourglass-half fa-fw"></i></span>
-                {{ _self.displayTime(coursesStat[course.tag].elapsedTime) }}
+                {{ displayTime(coursesStat[course.tag].elapsedTime) }}
           </span> 
         </div>
       {% endif %}
-      {{ _self.displayDate(coursesStat[course.tag].firstAccessDate)}}
+      {% set dateTime = coursesStat[course.tag].firstAccessDate %}
+      {{ include('@lms/learner-dashboard-date.twig') }}
   </div>
 
   <h3 class="dashboard-module">{{ _t('LMS_MODULES')}}</h3>
@@ -70,22 +72,3 @@
   </div>
  </div>
 </div>
-{{ include_css('tools/lms/presentation/styles/lms.css') }}
-
-{% macro displayTime(dateInterval) %}
-  {% if dateInterval.h > 0 or dateInterval.d > 0 or dateInterval.i > 60 %}
-      {{ dateInterval.format('%h h %I min.') }}
-  {% else %}
-      {{ dateInterval.format('%i min.') }}
-  {% endif %}
-{% endmacro %}
-{% macro displayDate(dateTime) %}
-  {% if dateTime %}
-    <div class="first-access">
-      <span title="{{ _t('LMS_DASHBOARD_FIRSTACCESS') }}">
-        <span class="label-icon"><i class="fas fa-calendar-alt"></i></span>
-        {{ dateTime.isoFormat('LLLL')}}
-      </span>
-    </div>
-  {% endif %}
-{% endmacro %}

--- a/templates/learner-update-elapsed-time.twig
+++ b/templates/learner-update-elapsed-time.twig
@@ -5,23 +5,21 @@
     {{- '" ?'}}</h3>
 <form action="{{ url({tag:'',
                       handler:'UpdateElapsedTime',
-                      params:{learner:learner.getUsername,course:course.tag,module:module.tag,activity:activity.tag,previousparams:previousparamskeys}}) }}"
+                      params: {learner: learner.username, course: course.tag, module: module.tag, activity: activity.tag, previousparams: previousparams|keys|join(',')}}) }}"
                       method="POST" name="formulaire" id="formulaire" enctype="multipart/form-data" class="form-horizontal">
-  <input id="elpasedtime" name="elapsedtime" class="form-control" 
+  <input id="elapsedtime" name="elapsedtime" class="form-control"
     value="{{ activity ? 
-      (coursesStat[course.tag].modulesStat[module.tag].activitiesStat[activity.tag].elapsedTime ? 
-          coursesStat[course.tag].modulesStat[module.tag].activitiesStat[activity.tag].elapsedTime.h * 60 + 
-          coursesStat[course.tag].modulesStat[module.tag].activitiesStat[activity.tag].elapsedTime.i : activity.duration) : 
-      (coursesStat[course.tag].modulesStat[module.tag].elapsedTime ? 
-          coursesStat[course.tag].modulesStat[module.tag].elapsedTime.h * 60 + 
-          coursesStat[course.tag].modulesStat[module.tag].elapsedTime.i : module.duration) }}" 
+      (coursesStat[course.tag].modulesStat[module.tag].activitiesStat[activity.tag].elapsedTime ?
+    coursesStat[course.tag].modulesStat[module.tag].activitiesStat[activity.tag].elapsedTime.totalMinutes : activity.duration) :
+      (coursesStat[course.tag].modulesStat[module.tag].elapsedTime ?
+          coursesStat[course.tag].modulesStat[module.tag].elapsedTime.totalMinutes : module.duration) }}"
     min="0" type="text">
   </input> {{ _t('LMS_UPDATE_ELAPSED_TIME_MINUTES') }}
   <hidden >
   <div class="form-actions form-group">
     <div class="col-sm-9 col-sm-offset-3">
       <button type="submit" class="btn btn-primary">{{ _t('BAZ_VALIDER') }}</button>
-      <a class="btn btn-xs btn-default" href="{{ url({tag: '',params:previousparams}) }}"
+      <a class="btn btn-xs btn-default" href="{{ url({tag: '', params: previousparams}) }}"
         title="{{ _t('BAZ_ANNULER') }}">
         {{ _t('BAZ_ANNULER') }}
       </a>

--- a/wiki.php
+++ b/wiki.php
@@ -9,9 +9,6 @@
  * @link     https://yeswiki.net
  */
 
-use YesWiki\Core\Service\TemplateEngine;
-use YesWiki\Lms\Controller\CourseController;
-
 if (!defined("WIKINI_VERSION")) {
     die("acc&egrave;s direct interdit");
 }


### PR DESCRIPTION
Voici le refacto que je propose pour toute la partie LearnerDashboard.

Au départ, j'étais parti juste pour uniformiser la gestion des date/durée et réécrire le traitement des paramètres (GET et parfois POST), mais de fil en aiguille, je suis repassé un peu partout.

J'ai fais attention à ne rien changer au niveau fonctionnalité, à part quelques exceptions.

- il y a le soucis de création automatique de progress pour les modules dont je vous ai parlé sur le canal LMS.
- en uniformisant les dates pour l'export CSV, j'ai modifié le format : j'ai remplacé ' 'xx h xx min' en 'xx:xx:xx' afin que les tableurs puissent reconnaître que c'est une durée
- pas encore commité, mais je vais également rajouter le fait que quand on clique pour modifier le temps passé pour un module, que l'accordéon ne s'ouvre pas (système déjà mis en place pour ProgressDashboard)

J'ai fais pas mal de tests mais ça faudrait le coup de tester davantage car il y a eu pas mal de code modifié.
