### PR TITLE
Affichage des durées de ProgressDashboard via les macros twig 

### DIFF
--- a/actions/CourseMenuAction.php
+++ b/actions/CourseMenuAction.php
@@ -5,6 +5,7 @@ use YesWiki\Core\YesWikiAction;
 use YesWiki\Lms\Activity;
 use YesWiki\Lms\Controller\CourseController;
 use YesWiki\Lms\Service\CourseManager;
+use YesWiki\Lms\Service\DateManager;
 use YesWiki\Lms\Service\LearnerManager;
 
 class CourseMenuAction extends YesWikiAction
@@ -16,6 +17,7 @@ class CourseMenuAction extends YesWikiAction
         $courseManager = $this->getService(CourseManager::class);
         $learnerManager = $this->getService(LearnerManager::class);
         $entryManager = $this->getService(EntryManager::class);
+        $dateManager = $this->getService(DateManager::class);
         $config = $this->wiki->config;
 
         // the course to display
@@ -51,7 +53,7 @@ class CourseMenuAction extends YesWikiAction
 
                 // the activity is not loaded from the manager because we don't want to requests the fields
                 // (it's an exception)
-                $activity = new Activity($config, $entryManager, $pageTag);
+                $activity = new Activity($config, $entryManager, $dateManager, $pageTag);
                 // if nav tabs are configurated and if the current activity is a tab activity, we refer now to the
                 // parent tab activity
                 $activity = $courseController->getParentTabActivity($activity);

--- a/actions/ProgressDashboardAction.php
+++ b/actions/ProgressDashboardAction.php
@@ -73,8 +73,6 @@ class ProgressDashboardAction extends YesWikiAction
         } else {
             return $this->renderCourseProgressDashboard($course);
         }
-
-        // TODO delete the admin user from the progresses
     }
 
     private function renderModuleProgressDashboard($module, $course): string
@@ -94,8 +92,6 @@ class ProgressDashboardAction extends YesWikiAction
             'activitiesStat' => $this->activitiesStat,
             'modulesStat' => $this->modulesStat,
             'learners' => $this->learners,
-            // TODO replace it by a Twig Macro
-            'formatter' => $this->courseController->getTwigFormatter()
         ]);
     }
 
@@ -113,8 +109,6 @@ class ProgressDashboardAction extends YesWikiAction
             'modulesStat' => $this->modulesStat,
             'courseStat' => $this->coursesStat,
             'learners' => $this->learners,
-            // TODO replace it by a Twig Macro
-            'formatter' => $this->courseController->getTwigFormatter()
         ]);
     }
 

--- a/controllers/CourseController.php
+++ b/controllers/CourseController.php
@@ -12,6 +12,7 @@ use YesWiki\Lms\Course;
 use YesWiki\Lms\Module;
 use YesWiki\Lms\ModuleStatus;
 use YesWiki\Lms\Service\CourseManager;
+use YesWiki\Lms\Service\DateManager;
 use YesWiki\Lms\Service\LearnerManager;
 
 class CourseController extends YesWikiController
@@ -19,6 +20,7 @@ class CourseController extends YesWikiController
     protected $entryManager;
     protected $courseManager;
     protected $learnerManager;
+    protected $dateManager;
     protected $config;
 
     /**
@@ -26,17 +28,20 @@ class CourseController extends YesWikiController
      * @param EntryManager $entryManager the injected EntryManager instance
      * @param CourseManager $courseManager the injected CourseManager instance
      * @param LearnerManager $learnerManager the injected LearnerManager instance
+     * @param DateManager $dateManager the injected DateManager instance
      * @param ParameterBagInterface $config the injected Wiki instance
      */
     public function __construct(
         EntryManager $entryManager,
         CourseManager $courseManager,
         LearnerManager $learnerManager,
+        DateManager $dateManager,
         ParameterBagInterface $config
     ) {
         $this->entryManager = $entryManager;
         $this->courseManager = $courseManager;
         $this->learnerManager = $learnerManager;
+        $this->dateManager = $dateManager;
         $this->config = $config->all();
     }
 
@@ -90,7 +95,7 @@ class CourseController extends YesWikiController
         if (!empty($currentPageTag) && $course) {
 
             // the activity is not loaded from the manager because we don't want to requests the fields (it's an exception)
-            $activity = new Activity($this->config, $this->entryManager, $currentPageTag);
+            $activity = new Activity($this->config, $this->entryManager, $this->dateManager, $currentPageTag);
 
             // if nav tabs are configurated and if the current activity is a tab activity, we refer now to the parent tab activity
             $activity = $this->getParentTabActivity($activity);
@@ -249,34 +254,5 @@ class CourseController extends YesWikiController
                 return _t('LMS_MODULE_NOT_ACCESSIBLE');
                 break;
         }
-    }
-
-    /**
-     * Create a formatter which have the specific twig function for the CourseStructure objects
-     * @return object the formatter (an object from the anonymous class)
-     * TODO replace it by a Twig Macro
-     */
-    public function getTwigFormatter()
-    {
-        // return the object which have all the twig formatting function
-        return new class() {
-            /**
-             * Render a duration in a corresponding string
-             * The format is 'XhXX' if the duration is equal or gretter than 1 hour, otherwise 'X min'
-             * @param int|null $duration the duration
-             * @return string the result string
-             */
-            function formatDuration(?int $duration): string
-            {
-                if (is_null($duration) || $duration == 0) {
-                    return '-';
-                }
-                $hours = floor($duration / 60);
-                $minutes = ($duration % 60);
-                return $hours != 0 ?
-                    sprintf('%dh%02d', $hours, $minutes)
-                    : sprintf('%d min', $minutes);
-            }
-        };
     }
 }

--- a/controllers/CourseController.php
+++ b/controllers/CourseController.php
@@ -204,9 +204,7 @@ class CourseController extends YesWikiController
             'labelStart' => $labelStart,
             'statusMsg' => $statusMsg,
             'disabledLink' => $disabledLink,
-            'learner' => $learner,
-            // TODO replace it by a Twig Macro
-            'formatter' => $this->getTwigFormatter()
+            'learner' => $learner
         ]);
     }
 
@@ -228,25 +226,16 @@ class CourseController extends YesWikiController
                 return _t('LMS_CLOSED_MODULE');
                 break;
             case ModuleStatus::TO_BE_OPEN:
-                return _t('LMS_MODULE_WILL_OPEN') . ' '
-                    . Carbon::now()->locale($GLOBALS['prefered_language'])->DiffForHumans($date,
-                        CarbonInterface::DIFF_ABSOLUTE)
-                    . ' (' . str_replace(' 00:00', '',
-                        $date->locale($GLOBALS['prefered_language'])->isoFormat('LLLL')) . ')';
+                return _t('LMS_MODULE_WILL_OPEN')
+                    . ' ' . $this->dateManager->diffDatesInReadableFormat($date)
+                    . ' (' . $this->dateManager->formatLongDate($date) . ')';
                 break;
             case ModuleStatus::OPEN:
                 $msg = _t('LMS_OPEN_MODULE');
                 if (!empty($date)) {
                     $msg .= ' ' . _t('LMS_SINCE')
-                        . ' ' . Carbon::now()->locale($GLOBALS['prefered_language'])->DiffForHumans(
-                            $date,
-                            CarbonInterface::DIFF_ABSOLUTE
-                        )
-                        . ' (' . str_replace(
-                            ' 00:00',
-                            '',
-                            $date->locale($GLOBALS['prefered_language'])->isoFormat('LLLL')
-                        ) . ')';
+                        . ' ' . $this->dateManager->diffDatesInReadableFormat($date)
+                        . ' (' . $this->dateManager->formatLongDate($date) . ')';
                 }
                 return $msg;
                 break;

--- a/controllers/CourseController.php
+++ b/controllers/CourseController.php
@@ -227,14 +227,14 @@ class CourseController extends YesWikiController
                 break;
             case ModuleStatus::TO_BE_OPEN:
                 return _t('LMS_MODULE_WILL_OPEN')
-                    . ' ' . $this->dateManager->diffDatesInReadableFormat($date)
+                    . ' ' . $this->dateManager->diffToNowInReadableFormat($date)
                     . ' (' . $this->dateManager->formatLongDate($date) . ')';
                 break;
             case ModuleStatus::OPEN:
                 $msg = _t('LMS_OPEN_MODULE');
                 if (!empty($date)) {
                     $msg .= ' ' . _t('LMS_SINCE')
-                        . ' ' . $this->dateManager->diffDatesInReadableFormat($date)
+                        . ' ' . $this->dateManager->diffToNowInReadableFormat($date)
                         . ' (' . $this->dateManager->formatLongDate($date) . ')';
                 }
                 return $msg;

--- a/handlers/ExportDashboardCsvHandler.php
+++ b/handlers/ExportDashboardCsvHandler.php
@@ -100,7 +100,7 @@ class ExportDashboardCsvHandler extends YesWikiHandler
                 $progressRatio,
                 $elapsedTime /* TODO elapsedTime */,
                 $courseStat['firstAccessDate'] ?
-                    $this->dateManager->formatDateWithWrittenMonth($courseStat['firstAccessDate'])
+                    $this->dateManager->formatLongDatetime($courseStat['firstAccessDate'])
                     : null
             ];
             fputcsv($output, $row);
@@ -125,7 +125,7 @@ class ExportDashboardCsvHandler extends YesWikiHandler
                     $progressRatio,
                     $elapsedTime,
                     $moduleStat['firstAccessDate'] ?
-                        $this->dateManager->formatDateWithWrittenMonth($moduleStat['firstAccessDate'])
+                        $this->dateManager->formatLongDatetime($moduleStat['firstAccessDate'])
                         : null
                 ];
                 fputcsv($output, $row);
@@ -148,7 +148,7 @@ class ExportDashboardCsvHandler extends YesWikiHandler
                         $progressRatio,
                         $elapsedTime,
                         $activityStat['firstAccessDate'] ?
-                            $this->dateManager->formatDateWithWrittenMonth($activityStat['firstAccessDate'])
+                            $this->dateManager->formatLongDatetime($activityStat['firstAccessDate'])
                             : null
                     ];
                     fputcsv($output, $row);

--- a/libs/Activity.php
+++ b/libs/Activity.php
@@ -2,14 +2,14 @@
 
 namespace YesWiki\Lms;
 
-use Carbon\Carbon;
 use Carbon\CarbonInterval;
-use \DateInterval;
-use YesWiki\Lms\CourseStructure;
+use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Lms\Service\DateManager;
 
 class Activity extends CourseStructure
 {
-    protected $duration; // estimated time to complete the module, it's an integer counting the number of minutes
+    // estimated time to complete the module, it's a CarbonInterval object
+    protected $duration;
 
     /**
      * Check if the comments are enable for this activity
@@ -31,17 +31,17 @@ class Activity extends CourseStructure
 
     /**
      * Getter for 'bf_duree' of the activity entry
-     * @return int the duration in minutes or 0 if not defined or not an integer
+     * @return CarbonInterval|null the duration or null if duration is zero or the activity has no duration
      */
-    public function getDuration(): int
+    public function getDuration(): ?CarbonInterval
     {
         // lazy loading
         if (is_null($this->duration)) {
             $duration = $this->getField('bf_duree');
             if ($duration && is_numeric($duration) && is_int(intval($duration))) {
-                $this->duration = intval($duration);
+                $this->duration = $this->dateManager->createIntervalFromMinutes(intval($duration));
             } else {
-                $this->duration = 0;
+                $this->duration = null;
             }
         }
         return $this->duration;

--- a/libs/CourseStructure.php
+++ b/libs/CourseStructure.php
@@ -3,6 +3,7 @@
 namespace YesWiki\Lms;
 
 use YesWiki\Bazar\Service\EntryManager;
+use YesWiki\Lms\Service\DateManager;
 
 abstract class CourseStructure
 {
@@ -16,17 +17,21 @@ abstract class CourseStructure
     protected $config;
     // manager used to get object entries
     protected $entryManager;
+    // manager used to format dates
+    protected $dateManager;
 
     /**
      * CourseStructure constructor
      * @param array $config the configuration parameters of YesWiki
      * @param EntryManager $entryManager the manager used to get object entries
+     * @param DateManager $dateManager the manager used to format dates
      * @param string $objectTag the object tag
      * @param array|null $objectFields the object fields if needed to populate directly the object
      */
     public function __construct(
         array $config,
         EntryManager $entryManager,
+        DateManager $dateManager,
         string $objectTag,
         array $objectFields = null
     ) {
@@ -38,6 +43,7 @@ abstract class CourseStructure
 
         $this->config = $config;
         $this->entryManager = $entryManager;
+        $this->dateManager = $dateManager;
     }
 
     /**

--- a/libs/bazarlms.fonct.inc.php
+++ b/libs/bazarlms.fonct.inc.php
@@ -15,6 +15,7 @@ use YesWiki\Lms\Controller\CourseController;
 use YesWiki\Lms\Course;
 use YesWiki\Lms\ModuleStatus;
 use YesWiki\Lms\Service\CourseManager;
+use YesWiki\Lms\Service\DateManager;
 use YesWiki\Lms\Service\LearnerManager;
 use YesWiki\Wiki;
 
@@ -43,6 +44,7 @@ function navigationactivite(&$formtemplate, $tableau_template, $mode, $fiche)
     $courseController = $GLOBALS['wiki']->services->get(CourseController::class);
     $entryManager = $GLOBALS['wiki']->services->get(EntryManager::class);
     $learnerManager = $GLOBALS['wiki']->services->get(LearnerManager::class);
+    $dateManager = $GLOBALS['wiki']->services->get(DateManager::class);
 
     // the tag of the current activity page
     $currentActivityTag = !empty($fiche['id_fiche']) ? $fiche['id_fiche'] : null;
@@ -50,7 +52,7 @@ function navigationactivite(&$formtemplate, $tableau_template, $mode, $fiche)
     $output = '';
     if ($mode == 'html' && $currentActivityTag) {
         // the activity is not loaded from the manager because we don't want to requests the fields (it's an exception)
-        $activity = new Activity($config, $entryManager, $currentActivityTag);
+        $activity = new Activity($config, $entryManager, $dateManager, $currentActivityTag);
 
         // if nav tabs are configurated and if the current activity is a tab activity, we refer now to the parent tab activity
         $activity = $courseController->getParentTabActivity($activity);

--- a/services/CourseManager.php
+++ b/services/CourseManager.php
@@ -3,7 +3,6 @@
 namespace YesWiki\Lms\Service;
 
 use YesWiki\Bazar\Service\EntryManager;
-use YesWiki\Core\Service\TripleStore;
 use YesWiki\Core\Service\UserManager;
 use YesWiki\Core\YesWikiService;
 use YesWiki\Lms\Activity;
@@ -16,6 +15,7 @@ class CourseManager
     protected $config;
     protected $entryManager;
     protected $userManager;
+    protected $dateManager;
     protected $activityFormId;
     protected $moduleFormId;
     protected $courseFormId;
@@ -25,17 +25,18 @@ class CourseManager
      * @param Wiki $wiki the injected Wiki instance
      * @param EntryManager $entryManager the injected EntryManager instance
      * @param UserManager $userManager the injected UserManager instance
-     * @param TripleStore $tripleStore the injected TripleStore instance
+     * @param DateManager $dateManager the injected UserManager instance
      */
     public function __construct(
         Wiki $wiki,
         EntryManager $entryManager,
         UserManager $userManager,
-        TripleStore $tripleStore
+        DateManager $dateManager
     ) {
         $this->config = $wiki->config;
         $this->entryManager = $entryManager;
         $this->userManager = $userManager;
+        $this->dateManager = $dateManager;
         $this->activityFormId = $this->config['lms_config']['activity_form_id'];
         $this->moduleFormId = $this->config['lms_config']['module_form_id'];
         $this->courseFormId = $this->config['lms_config']['course_form_id'];
@@ -51,7 +52,7 @@ class CourseManager
     {
         $activityEntry = $this->entryManager->getOne($entryTag);
         if ($activityEntry && intval($activityEntry['id_typeannonce']) == $this->activityFormId) {
-            return new Activity($this->config, $this->entryManager, $activityEntry['id_fiche'], $activityEntry);
+            return new Activity($this->config, $this->entryManager, $this->dateManager, $activityEntry['id_fiche'], $activityEntry);
         } else {
             return null;
         }
@@ -67,7 +68,7 @@ class CourseManager
     {
         $moduleEntry = $this->entryManager->getOne($entryTag);
         if ($moduleEntry && intval($moduleEntry['id_typeannonce']) == $this->moduleFormId) {
-            return new Module($this->config, $this->entryManager, $moduleEntry['id_fiche'], $moduleEntry);
+            return new Module($this->config, $this->entryManager, $this->dateManager, $moduleEntry['id_fiche'], $moduleEntry);
         } else {
             return null;
         }
@@ -83,7 +84,7 @@ class CourseManager
     {
         $courseEntry = $this->entryManager->getOne($entryTag);
         if ($courseEntry && intval($courseEntry['id_typeannonce']) == $this->courseFormId) {
-            return new Course($this->config, $this->entryManager, $courseEntry['id_fiche'], $courseEntry);
+            return new Course($this->config, $this->entryManager, $this->dateManager, $courseEntry['id_fiche'], $courseEntry);
         } else {
             return null;
         }
@@ -101,7 +102,7 @@ class CourseManager
             [] :
             array_map(
                 function ($courseEntry) {
-                    return new Course($this->config, $this->entryManager, $courseEntry['id_fiche'], $courseEntry);
+                    return new Course($this->config, $this->entryManager, $this->dateManager, $courseEntry['id_fiche'], $courseEntry);
                 },
                 $entries
             );

--- a/services/DateManager.php
+++ b/services/DateManager.php
@@ -57,7 +57,13 @@ class DateManager
 
     public function formatTimeWithColons(CarbonInterval $duration): string
     {
-        return $duration->format(self::TIME_FORMAT_WITH_COLONS);
+        // create new CarbonInterval to set total hours without cascade
+        // difference between 2021-01-01 00:00:00 and 2021-01-02 01:05:00 should give 25:05:00
+        // whereas $duration->format(self::TIME_FORMAT_WITH_COLONS) gives 01:05:00
+        return CarbonInterval::hours($duration->totalHours)
+            ->minutes($duration->minutes)
+            ->seconds($duration->seconds)
+            ->format(self::TIME_FORMAT_WITH_COLONS);
     }
 
     public function formatLongDatetime(Carbon $date): string

--- a/services/DateManager.php
+++ b/services/DateManager.php
@@ -4,15 +4,19 @@
 namespace YesWiki\Lms\Service;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
 use Exception;
 use YesWiki\Wiki;
 
 class DateManager
 {
-    protected const DATE_FORMAT = 'Y-m-d H:i:s';
+
+    protected const DATETIME_FORMAT = 'Y-m-d H:i:s';
     protected const TIME_FORMAT_WITH_COLONS = '%H:%I:%S';
     protected const TIME_FORMAT_WITH_COLONS_FOR_IMPORT = 'H:i:s';
+    protected const LONG_DATE_ISOFORMAT = 'LL';
+    protected const LONG_DATETIME_ISOFORMAT = 'LLLL';
     protected $config;
 
     /**
@@ -24,9 +28,9 @@ class DateManager
         $this->config = $wiki->config;
     }
 
-    public function createDateFromString(string $dateStr): ?Carbon
+    public function createDatetimeFromString(string $dateStr): ?Carbon
     {
-        $date = Carbon::createFromFormat(self::DATE_FORMAT, $dateStr);
+        $date = Carbon::createFromFormat(self::DATETIME_FORMAT, $dateStr);
         // TODO manage the timezone
         if (!$date) {
             //error_log("Error by parsing the date. The format 'Y-m-d H:i:s' is expected but '$dateStr' is given");
@@ -56,16 +60,30 @@ class DateManager
         return $duration->format(self::TIME_FORMAT_WITH_COLONS);
     }
 
-    public function formatDateWithWrittenMonth(Carbon $date): string
+    public function formatLongDatetime(Carbon $date): string
     {
-        return $date->locale($GLOBALS['prefered_language'])->isoFormat('LLLL');
+        return $date->locale($GLOBALS['prefered_language'])->isoFormat(self::LONG_DATETIME_ISOFORMAT);
     }
 
-    public function formatDateToString(Carbon $date = null): string
+    public function formatLongDate(Carbon $date): string
+    {
+        return $date->locale($GLOBALS['prefered_language'])->isoFormat(self::LONG_DATE_ISOFORMAT);
+    }
+
+    public function formatDatetimeToString(Carbon $date = null): string
     {
         if (is_null($date)) {
             $date = Carbon::now();
         }
-        return $date->locale($GLOBALS['prefered_language'])->format(self::DATE_FORMAT);
+        return $date->locale($GLOBALS['prefered_language'])->format(self::DATETIME_FORMAT);
+    }
+
+    public function diffDatesInReadableFormat(Carbon $fromDate, Carbon $toDate = null): string
+    {
+        if (is_null($toDate)){
+            $toDate = Carbon::now();
+        }
+        return $toDate->locale($GLOBALS['prefered_language'])->DiffForHumans($fromDate,
+            CarbonInterface::DIFF_ABSOLUTE);
     }
 }

--- a/services/LearnerDashboardManager.php
+++ b/services/LearnerDashboardManager.php
@@ -209,7 +209,7 @@ class LearnerDashboardManager
                     $this->dateManager->createIntervalFromString($progress['elapsed_time'])
                     : null;
             } else {
-                $activityDuration = $this->dateManager->createIntervalFromMinutes($activity->getDuration());
+                $activityDuration = $activity->getDuration();
             }
 
             $firstAccessDate = !empty($progress['log_time']) ?

--- a/services/LearnerDashboardManager.php
+++ b/services/LearnerDashboardManager.php
@@ -85,8 +85,8 @@ class LearnerDashboardManager
                 "started" => $started, // bool
                 "finished" => $finished, //bool
                 "progressRatio" => $progressRatio, // int between 0 and 100 in pourcent
-                "elapsedTime" => $courseDuration, // CarbonInterval object,
-                "firstAccessDate" => $this->findFirstAccessDate($modulesStat), // Carbon object,
+                "elapsedTime" => $courseDuration, // CarbonInterval object
+                "firstAccessDate" => $this->findFirstAccessDate($modulesStat), // Carbon object
                 "modulesStat" => $modulesStat
             ];
         }

--- a/services/LearnerDashboardManager.php
+++ b/services/LearnerDashboardManager.php
@@ -139,7 +139,7 @@ class LearnerDashboardManager
 
             // the first access date displayed is the earliest log_time between the module and all its activities
             $firstAccessDate = !empty($progress['log_time']) ?
-                $this->dateManager->createDateFromString($progress['log_time'])
+                $this->dateManager->createDatetimeFromString($progress['log_time'])
                 : null;
             $firstActivityAccessDate = $this->findFirstAccessDate($activitiesStat);
             if (($firstActivityAccessDate && $firstActivityAccessDate->lessThan($firstAccessDate))
@@ -213,7 +213,7 @@ class LearnerDashboardManager
             }
 
             $firstAccessDate = !empty($progress['log_time']) ?
-                $this->dateManager->createDateFromString($progress['log_time'])
+                $this->dateManager->createDatetimeFromString($progress['log_time'])
                 : null;
 
             $activitiesStat[$activity->getTag()] = [

--- a/services/LearnerDashboardManager.php
+++ b/services/LearnerDashboardManager.php
@@ -21,26 +21,28 @@ class LearnerDashboardManager
     protected $userManager;
     protected $courseManager;
     protected $dateManager;
+    protected $learnerManager;
 
     /**
      * LearnerDashboardManager constructor
      * @param Wiki $wiki the injected Wiki instance
      * @param UserManager $userManager the injected UserManager instance
      * @param CourseManager $courseManager the injected CourseManager instance
+     * @param LearnerManager $learnerManager the injected LearnerManager instance
      * @param DateManager $dateManager the injected DateManager instance
      */
     public function __construct(
         Wiki $wiki,
         UserManager $userManager,
         CourseManager $courseManager,
-        DateManager $dateManager,
-        LearnerManager $learnerManager
+        LearnerManager $learnerManager,
+        DateManager $dateManager
     ) {
         $this->wiki = $wiki;
         $this->userManager = $userManager;
         $this->courseManager = $courseManager;
-        $this->dateManager = $dateManager;
         $this->learnerManager = $learnerManager;
+        $this->dateManager = $dateManager;
     }
 
     /**

--- a/services/LearnerManager.php
+++ b/services/LearnerManager.php
@@ -190,7 +190,7 @@ class LearnerManager
             + ($activity ?
                 ['activity' => $activity->getTag()]
                 : [])
-            + ['log_time' => $this->dateManager->formatDateToString()];
+            + ['log_time' => $this->dateManager->formatDatetimeToString()];
         $resultState = $this->tripleStore->create(
             $learner->getUsername(),
             self::LMS_TRIPLE_PROPERTY_NAME_PROGRESS,

--- a/services/LearnerManager.php
+++ b/services/LearnerManager.php
@@ -190,7 +190,7 @@ class LearnerManager
             + ($activity ?
                 ['activity' => $activity->getTag()]
                 : [])
-            + ['log_time' => $this->dateManager->formatDatetimeToString()];
+            + ['log_time' => $this->dateManager->formatDatetime()];
         $resultState = $this->tripleStore->create(
             $learner->getUsername(),
             self::LMS_TRIPLE_PROPERTY_NAME_PROGRESS,

--- a/templates/bazar/fiche-1203.tpl.html
+++ b/templates/bazar/fiche-1203.tpl.html
@@ -11,11 +11,13 @@ use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Core\Service\TemplateEngine;
 use YesWiki\Lms\Controller\CourseController;
 use YesWiki\Lms\Course;
+use YesWiki\Lms\Service\DateManager;
 use YesWiki\Lms\Service\LearnerManager;
 
 $courseController = $GLOBALS['wiki']->services->get(CourseController::class);
 $entryManager = $GLOBALS['wiki']->services->get(EntryManager::class);
 $learnerManager = $GLOBALS['wiki']->services->get(LearnerManager::class);
+$dateManager = $GLOBALS['wiki']->services->get(DateManager::class);
 
 // the current learner
 $learner = $learnerManager->getLearner();
@@ -24,7 +26,7 @@ echo '<div class="course-container' . ($learner && $learner->isAdmin() ? ' admin
 
 if ($fiche && intval($fiche['id_typeannonce']) == $GLOBALS['wiki']->config['lms_config']['course_form_id']) {
     // no use of $courseManager->getCourse because sometimes the entry isn't in the db (for importation preview per example)
-    $course = new Course($GLOBALS['wiki']->config, $entryManager, $fiche['id_fiche'], $fiche);
+    $course = new Course($GLOBALS['wiki']->config, $entryManager, $dateManager, $fiche['id_fiche'], $fiche);
 
     if (!empty($html['bf_titre'])) {
         echo '<h1 class="course-title">' . $html['bf_titre'] . '</h1>';

--- a/templates/module-card.twig
+++ b/templates/module-card.twig
@@ -1,3 +1,4 @@
+{% from "@lms/datetime-macros.twig" import displayTime %}
 {% block module_card %}
     <div class="module-card status-{{ module.status(course) }}">
     <div class="module-image">
@@ -18,7 +19,7 @@
                 : {{ nbActivities }}
             </div>
             <div class="activities-duration"><strong><i class="fas fa-hourglass-half fa-fw"></i> {{ _t('LMS_ESTIMATED_TIME') }}</strong>
-                : {{ formatter.formatDuration(module.duration) }}
+                : {{ displayTime(module.duration) }}
             </div>
         </div>
         <div class="activities-action">

--- a/templates/progress-dashboard-course.twig
+++ b/templates/progress-dashboard-course.twig
@@ -1,3 +1,4 @@
+{% from "@lms/datetime-macros.twig" import displayTime %}
 <h1 class="dashboard-title">{{ _t('LMS_PROGRESS_DASHBOARD') }}</h1>
 
 <h3 class="dashboard-course course-back">
@@ -22,7 +23,7 @@
     </div>
     <div class="estimated-time">
         <span title="{{ _t('LMS_ESTIMATED_TIME_DETAILLED') }}">
-            <span class="label-icon"><i class="fas fa-hourglass-half fa-fw"></i> est.</span>{{ formatter.formatDuration(course.duration) }}
+            <span class="label-icon"><i class="fas fa-hourglass-half fa-fw"></i> est.</span>{{ displayTime(course.duration) }}
         </span>
     </div>
 </div>

--- a/templates/progress-dashboard-included-activity.twig
+++ b/templates/progress-dashboard-included-activity.twig
@@ -1,3 +1,4 @@
+{% from "@lms/datetime-macros.twig" import displayTime %}
 <div class="panel panel-lms-dashboard dashboard-activity-frame collapsed">
     <div id="heading_{{ activity.tag }}" class="panel-heading collapsed" role="tab button" data-toggle="collapse"
          href="#collapse_{{ activity.tag }}" aria-expanded="false" aria-controls="collapse_{{ activity.tag }}">
@@ -18,7 +19,7 @@
         <div class="estimated-time">
             <span title="{{ _t('LMS_ESTIMATED_TIME_DETAILLED') }}">
                 <span class="label-icon"><i class="fas fa-hourglass-half fa-fw"></i> est.</span>
-                {{ formatter.formatDuration(activity.duration) }}
+                {{ displayTime(activity.duration) }}
             </span>
         </div>
     </div>

--- a/templates/progress-dashboard-included-module.twig
+++ b/templates/progress-dashboard-included-module.twig
@@ -1,3 +1,4 @@
+{% from "@lms/datetime-macros.twig" import displayTime %}
 <div class="panel panel-lms-dashboard dashboard-module-frame collapsed">
     <div id="heading_{{ module.tag }}" class="panel-heading collapsed" role="tab button" data-toggle="collapse"
          href="#collapse_{{ module.tag }}" aria-expanded="false" aria-controls="collapse_{{ module.tag }}">
@@ -21,7 +22,7 @@
         <div class="estimated-time">
             <span title="{{ _t('LMS_ESTIMATED_TIME_DETAILLED') }}">
                 <span class="label-icon"><i class="fas fa-hourglass-half fa-fw"></i> est.</span>
-                {{ formatter.formatDuration(module.duration) }}
+                {{ displayTime(module.duration) }}
             </span>
         </div>
     </div>

--- a/templates/progress-dashboard-module.twig
+++ b/templates/progress-dashboard-module.twig
@@ -1,3 +1,4 @@
+{% from "@lms/datetime-macros.twig" import displayTime %}
 <h1 class="dashboard-title">{{ _t('LMS_PROGRESS_DASHBOARD') }}</h1>
 
 <h3 class="dashboard-course course-back">
@@ -24,7 +25,7 @@
     <div class="estimated-time">
         <span title="{{ _t('LMS_ESTIMATED_TIME_DETAILLED') }}">
             <span class="label-icon"><i class="fas fa-hourglass-half fa-fw"></i> est.</span>
-            {{ formatter.formatDuration(module.duration) }}
+            {{ displayTime(module.duration) }}
         </span>
     </div>
 </div>


### PR DESCRIPTION
use CarbonInterval for duration in the CourseStucture objects & datetime macros in ProgressDashboard

Il y avait déjà le système de macro twig pour gérer l'affichage des date/durée mis en place. J'avais mis à jour le LearnerDashboard, mais il restait le ProgressDashboard qui passait par une bidouille de contrôleur. 
Amélioration liée : maintenant le getDuration des CoursesStructures rend un CarbonInterval et plus un int.

Vu que tu es en plein dev, @J9rem j'ai créé une branche afin d'être sûr que ça ne pose pas de soucis. J'attends ton OK pour merger. Normalement, ça ne devrait pas bcp impacter tes devs.




