### PR TITLE
fix(LearnerManager->saveElapsedTimeForLearner): create module log_tim…

### DIFF
--- a/services/LearnerManager.php
+++ b/services/LearnerManager.php
@@ -76,7 +76,11 @@ class LearnerManager
             || !$course->hasModule($module->getTag())) {
             return false;
         }
-        return $this->saveActivityOrModuleProgress($course, $module, $activity);
+        if (!$this->saveActivityOrModuleProgress($course, $module, $activity)) {
+            return false;
+        }
+        // save also for module if needed
+        return $this->saveActivityOrModuleProgress($course, $module, null);
     }
 
     public function saveModuleProgress(Course $course, Module $module): bool


### PR DESCRIPTION
…e when needed

Effectivement, dans les cas possibles (même s'ils peuvent être rares dans certaines configurations), il est possible de commencer des `activity` et de créer des log_time pour les activités sans avoir créer de log_time pour le module en question.

Sauf que pour définir le temps passé personnalisé pour ce module, il faut la présence d'un log_time.
Je propose d'automatiser cette création de log_time au moment de la définition d'un temps passé personnalisé en choisissant le log_time de la première activité commencée dans ce module.

OK pour toi @acheype ?