### PR TITLE
Lms21 spec5 quiz api

### DIFF
--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -14,12 +14,21 @@ class ApiController extends YesWikiController
      * Get quiz's results for a user, course, module, activity and quizId
      * @Route("/api/lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}",methods={"GET"},options={"acl":{"public","+"}})
      */
-    public function getQuizResultsForAUserAndAQuizz($userId, $courseId, $moduleId, $activityId, $quizId)
+    public function getQuizResultsForAUserAndAQuiz($userId, $courseId, $moduleId, $activityId, $quizId)
     {
         return new ApiResponse(
             $this->getService(QuizManager::class)
-                ->getQuizResultsForAUserAndAQuizz($userId, $courseId, $moduleId, $activityId, $quizId)
+                ->getQuizResultsForAUserAndAQuiz($userId, $courseId, $moduleId, $activityId, $quizId)
         );
+    }
+
+    /**
+     * Get quiz's results for a user, course, module, activity and quizId
+     * @Route("/api/lms/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getQuizResultsForAQuizz($courseId, $moduleId, $activityId, $quizId)
+    {
+        return $this->getQuizResultsForAUserAndAQuiz(null, $courseId, $moduleId, $activityId, $quizId);
     }
     
     /**
@@ -77,6 +86,12 @@ class ApiController extends YesWikiController
         $output .= '"'.QuizManager::MESSAGE_LABEL.'":"error message of needed",]</code><br />';
         $output .= '<b>You must sent cookies to be connected as learner or admin.</b><br />';
 
+        $output .= '<br />GET <a href="';
+        $output .= $this->wiki->Href('lms/quizresults/test-course/test-module/test-activity/test-id', 'api');
+        $output .= '"><code>';
+        $output .= $this->wiki->Href('lms/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
+        $output .= '</code></a><br />';
+        $output .= 'Same as previous but for current connected leaner<br />';
         
         $urlSaveQuizzResult = $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
         $output .= '<br />The following code :<br />';
@@ -87,6 +102,11 @@ class ApiController extends YesWikiController
         $output .= QuizManager::STATUS_CODE_ERROR.' = error,<br />';
         $output .= '"message":"error message"]</code><br />';
         $output .= '<b>You must sent cookies to be connected as learner or admin.</b><br />';
+        
+        $output .= '<br />POST <b><code>';
+        $output .= $this->wiki->Href('lms/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
+        $output .= '</code></b><br />';
+        $output .= 'Same as previous but for current connected leaner<br />';
         return $output;
     }
 }

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -18,17 +18,116 @@ class ApiController extends YesWikiController
     {
         return new ApiResponse(
             $this->getService(QuizManager::class)
-                ->getQuizResultsForAUserAndAQuiz($userId, $courseId, $moduleId, $activityId, $quizId)
+                ->getQuizResults($userId, $courseId, $moduleId, $activityId, $quizId)
         );
     }
 
     /**
-     * Get quiz's results for a user, course, module, activity and quizId
+     * Get quizzes' results for a user, course, module, activity
+     * @Route("/api/lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getQuizResultsForAUserAndAnActivity($userId, $courseId, $moduleId, $activityId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->getQuizResults($userId, $courseId, $moduleId, $activityId, null)
+        );
+    }
+    
+    /**
+     * Get quizzes' results for a user, course, module
+     * @Route("/api/lms/users/{userId}/quizresults/{courseId}/{moduleId}",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getQuizResultsForAUserAndAModule($userId, $courseId, $moduleId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->getQuizResults($userId, $courseId, $moduleId, null, null)
+        );
+    }
+    
+    /**
+     * Get quizzes' results for a user, course
+     * @Route("/api/lms/users/{userId}/quizresults/{courseId}",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getQuizResultsForAUserAndACourse($userId, $courseId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->getQuizResults($userId, $courseId, null, null, null)
+        );
+    }
+    
+    /**
+     * Get quizzes' results for a user, course
+     * @Route("/api/lms/users/{userId}/quizresults",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getQuizResultsForAUser($userId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->getQuizResults($userId, null, null, null, null)
+        );
+    }
+
+    /**
+     * Get quiz's results for a course, module, activity and quizId (all users for admins otherwise only for current user)
      * @Route("/api/lms/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}",methods={"GET"},options={"acl":{"public","+"}})
      */
     public function getQuizResultsForAQuiz($courseId, $moduleId, $activityId, $quizId)
     {
-        return $this->getQuizResultsForAUserAndAQuiz(null, $courseId, $moduleId, $activityId, $quizId);
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->getQuizResults(null, $courseId, $moduleId, $activityId, $quizId)
+        );
+    }
+    
+    /**
+     * Get quiz's results for a course, module, activity (all users for admins otherwise only for current user)
+     * @Route("/api/lms/quizresults/{courseId}/{moduleId}/{activityId}",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getQuizResultsForAnActivity($courseId, $moduleId, $activityId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->getQuizResults(null, $courseId, $moduleId, $activityId, null)
+        );
+    }
+    
+    /**
+     * Get quiz's results for a course, module (all users for admins otherwise only for current user)
+     * @Route("/api/lms/quizresults/{courseId}/{moduleId}",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getQuizResultsForAModule($courseId, $moduleId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->getQuizResults(null, $courseId, $moduleId, null, null)
+        );
+    }
+
+    /**
+     * Get quiz's results for a course (all users for admins otherwise only for current user)
+     * @Route("/api/lms/quizresults/{courseId}",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getQuizResultsForACourse($courseId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->getQuizResults(null, $courseId, null, null, null)
+        );
+    }
+
+    /**
+     * Get quiz's results  (all users for admins otherwise only for current user)
+     * @Route("/api/lms/quizresults",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getQuizResults()
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->getQuizResults(null, null, null, null, null)
+        );
     }
     
     /**
@@ -73,17 +172,50 @@ class ApiController extends YesWikiController
     {
         $output = '<h2>Extension LMS</h2>';
 
-        $urlGetQuizResultsForAUserAndAQuiz = $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
-        $fullUrlGetQuizResultsForAUserAndAQuiz = $this->wiki->Href('lms/users/TestUser/quizresults/test-course/test-module/test-activity/test-id', 'api');
-
-        $output .= 'The following code :<br />';
-        $output .= 'GET <a href="'. $fullUrlGetQuizResultsForAUserAndAQuiz .'"><code>'.$urlGetQuizResultsForAUserAndAQuiz.'</code></a><br />';
-        $output .= 'gives a json with token results for the {quizId} quiz of activity {activityId} and for user {userId}<br />';
-        $output .= '<code>["'.QuizManager::STATUS_LABEL.'":'.QuizManager::STATUS_CODE_OK.' = OK/';
-        $output .= QuizManager::STATUS_CODE_ERROR.' = error/'.QuizManager::STATUS_CODE_NO_RESULT.' = no results,<br />';
-        $output .= '"'.QuizManager::RESULTS_LABEL.'":"[{"log_time":"2021-01-01 01:23:22","'.QuizManager::RESULT_LABEL.'":"23"}, // value in percent<br />';
-        $output .= '{"log_time":"2021-01-01 01:24:22","'.QuizManager::RESULT_LABEL.'":"32"}]", // value in percent<br />';
-        $output .= '"'.QuizManager::MESSAGE_LABEL.'":"error message of needed",]</code><br />';
+        $output .= 'The following codes give quiz\'s results:<br />';
+        $output .= 'GET <a href="';
+        $output .= $this->wiki->Href('lms/users/TestUser/quizresults/test-course/test-module/test-activity/test-id', 'api');
+        $output .= '"><code>';
+        $output .= $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
+        $output .= '</code></a> for a quiz<br />';
+        $output .= 'GET <a href="';
+        $output .= $this->wiki->Href('lms/users/TestUser/quizresults/test-course/test-module/test-activity', 'api');
+        $output .= '"><code>';
+        $output .= $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}', 'api');
+        $output .= '</code></a> for all quizzes of an activity<br />';
+        $output .= 'GET <a href="';
+        $output .= $this->wiki->Href('lms/users/TestUser/quizresults/test-course/test-module', 'api');
+        $output .= '"><code>';
+        $output .= $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}', 'api');
+        $output .= '</code></a> for all quizzes of all activities of a module<br />';
+        $output .= 'GET <a href="';
+        $output .= $this->wiki->Href('lms/users/TestUser/quizresults/test-course', 'api');
+        $output .= '"><code>';
+        $output .= $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}', 'api');
+        $output .= '</code></a> for all quizzes of all modules of a course<br />';
+        $output .= 'GET <a href="';
+        $output .= $this->wiki->Href('lms/users/TestUser/quizresults', 'api');
+        $output .= '"><code>';
+        $output .= $this->wiki->Href('lms/users/{userId}/quizresults', 'api');
+        $output .= '</code></a> for all quizzes for the user<br />';
+        $output .= '<br /><b>All routes can be used without \'/users/{userId}/\' to get all quizzes for all users<br>';
+        $output .= 'if connected as admin (otherwise current user)</b>. Example:<br />';
+        $output .= 'GET <a href="';
+        $output .= $this->wiki->Href('lms/quizresults/test-course/test-module/test-activity', 'api');
+        $output .= '"><code>';
+        $output .= $this->wiki->Href('lms/quizresults/{courseId}/{moduleId}/{activityId}', 'api');
+        $output .= '</code></a> for all quizzes of an activity for all users<br />';
+        $output .= '<br />Results in json<br />';
+        $output .= 'Error:<br />';
+        $output .= '<code>["'.QuizManager::STATUS_LABEL.'":'.QuizManager::STATUS_CODE_ERROR.',';
+        $output .= '"'.QuizManager::MESSAGE_LABEL.'":"error message if needed"]</code><br />';
+        $output .= 'Success:<br />';
+        $output .= '<code>["'.QuizManager::STATUS_LABEL.'":'.QuizManager::STATUS_CODE_OK.',';
+        $output .= '"'.QuizManager::RESULTS_LABEL.'":[{...},{...},<br>';
+        $output .= '{"learner":"userId","course":"courseId","module":"moduleId","activity":"activityId",<br>';
+        $output .= '"quizId":"quizId","log_time":"2021-01-01 01:23:22","'.QuizManager::RESULT_LABEL.'":"32"}]]// value in percent</code><br />';
+        $output .= 'No results:<br />';
+        $output .= '<code>["'.QuizManager::STATUS_LABEL.'":'.QuizManager::STATUS_CODE_NO_RESULT.']</code><br />';
         $output .= '<b>You must sent cookies to be connected as learner or admin.</b><br />';
 
         $output .= '<br />GET <a href="';

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -164,6 +164,123 @@ class ApiController extends YesWikiController
     }
 
     /**
+     * delete quiz's result for a user and for course, module, activity and quizId
+     * @Route("/api/lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}",methods={"DELETE"},options={"acl":{"+"}})
+     */
+    public function deleteQuizResultsForAUserAndAQuiz($userId, $courseId, $moduleId, $activityId, $quizId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->deleteQuizResults($userId, $courseId, $moduleId, $activityId, $quizId)
+        );
+    }
+
+    /**
+     * delete quiz's result for a user and for course, module, activity
+     * @Route("/api/lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}",methods={"DELETE"},options={"acl":{"+"}})
+     */
+    public function deleteQuizResultsForAUserAndAnActivity($userId, $courseId, $moduleId, $activityId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->deleteQuizResults($userId, $courseId, $moduleId, $activityId, null)
+        );
+    }
+    /**
+     * delete quiz's result for a user and for course, module
+     * @Route("/api/lms/users/{userId}/quizresults/{courseId}/{moduleId}",methods={"DELETE"},options={"acl":{"+"}})
+     */
+    public function deleteQuizResultsForAUserAndAModule($userId, $courseId, $moduleId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->deleteQuizResults($userId, $courseId, $moduleId, null, null)
+        );
+    }
+    /**
+     * delete quiz's result for a user and for course
+     * @Route("/api/lms/users/{userId}/quizresults/{courseId}",methods={"DELETE"},options={"acl":{"+"}})
+     */
+    public function deleteQuizResultsForAUserAndACourse($userId, $courseId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->deleteQuizResults($userId, $courseId, null, null, null)
+        );
+    }
+    /**
+     * delete quiz's result for a user
+     * @Route("/api/lms/users/{userId}/quizresults",methods={"DELETE"},options={"acl":{"+"}})
+     */
+    public function deleteQuizResultsForAUser($userId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->deleteQuizResults($userId, null, null, null, null)
+        );
+    }
+
+    /**
+     * delete quiz's result for all users and for course, module, activity and quizId
+     * @Route("/api/lms/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}",methods={"DELETE"},options={"acl":{"+"}})
+     */
+    public function deleteQuizResultsForAQuiz($courseId, $moduleId, $activityId, $quizId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->deleteQuizResults(null, $courseId, $moduleId, $activityId, $quizId)
+        );
+    }
+
+    /**
+     * delete quiz's result for all users and for course, module, activity
+     * @Route("/api/lms/quizresults/{courseId}/{moduleId}/{activityId}",methods={"DELETE"},options={"acl":{"+"}})
+     */
+    public function deleteQuizResultsForAnActivity($courseId, $moduleId, $activityId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->deleteQuizResults(null, $courseId, $moduleId, $activityId, null)
+        );
+    }
+
+    /**
+     * delete quiz's result for all users and for course, module
+     * @Route("/api/lms/quizresults/{courseId}/{moduleId}",methods={"DELETE"},options={"acl":{"+"}})
+     */
+    public function deleteQuizResultsForAModule($courseId, $moduleId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->deleteQuizResults(null, $courseId, $moduleId, null, null)
+        );
+    }
+
+    /**
+     * delete quiz's result for all users and for course
+     * @Route("/api/lms/quizresults/{courseId}",methods={"DELETE"},options={"acl":{"+"}})
+     */
+    public function deleteQuizResultsForACourse($courseId)
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->deleteQuizResults(null, $courseId, null, null, null)
+        );
+    }
+
+    /**
+     * delete quiz's result for all users
+     * @Route("/api/lms/quizresults",methods={"DELETE"},options={"acl":{"+"}})
+     */
+    public function deleteQuizResults()
+    {
+        return new ApiResponse(
+            $this->getService(QuizManager::class)
+                ->deleteQuizResults(null, null, null, null, null)
+        );
+    }
+
+    /**
      * Display lms api documentation
      *
      * @return string
@@ -239,6 +356,28 @@ class ApiController extends YesWikiController
         $output .= $this->wiki->Href('lms/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
         $output .= '</code></b><br />';
         $output .= 'Same as previous but for current connected leaner<br />';
+
+        
+        $output .= '<br />The following codes delete quiz\'s results:<br />';
+        $output .= 'DELETE <code>';
+        $output .= $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
+        $output .= '</code> for a quiz<br />';
+        $output .= 'DELETE <code>';
+        $output .= $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}', 'api');
+        $output .= '</code> for all quizzes of an activity<br />';
+        $output .= 'DELETE <code>';
+        $output .= $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}', 'api');
+        $output .= '</code> for all quizzes of a module<br />';
+        $output .= 'DELETE <code>';
+        $output .= $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}', 'api');
+        $output .= '</code> for all quizzes of a course<br />';
+        $output .= 'DELETE <code>';
+        $output .= $this->wiki->Href('lms/users/{userId}/quizresults', 'api');
+        $output .= '</code> for all quizzes of a user<br />';
+        $output .= 'DELETE <code>';
+        $output .= $this->wiki->Href('lms/quizresults', 'api');
+        $output .= '</code> for all quizzes of all user<br />';
+        $output .= '<b>You must sent cookies to be connected as admin.</b><br />';
         return $output;
     }
 }

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -5,8 +5,7 @@ namespace YesWiki\Lms\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 use YesWiki\Core\ApiResponse;
 use YesWiki\Core\YesWikiController;
-use YesWiki\Lms\Service\ActivityConditionsManager;
-use YesWiki\Lms\Service\CourseManager;
+use YesWiki\Lms\Service\QuizManager;
 
 class ApiController extends YesWikiController
 {
@@ -17,7 +16,8 @@ class ApiController extends YesWikiController
     public function getQuizzToken($course, $module, $activity)
     {
         return new ApiResponse(
-            ['status' => false,'token' => "1234A"]
+            $this->getService(QuizManager::class)
+                ->getQuizToken($course, $module, $activity)
         );
     }
     

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -26,7 +26,7 @@ class ApiController extends YesWikiController
      * Get quiz's results for a user, course, module, activity and quizId
      * @Route("/api/lms/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}",methods={"GET"},options={"acl":{"public","+"}})
      */
-    public function getQuizResultsForAQuizz($courseId, $moduleId, $activityId, $quizId)
+    public function getQuizResultsForAQuiz($courseId, $moduleId, $activityId, $quizId)
     {
         return $this->getQuizResultsForAUserAndAQuiz(null, $courseId, $moduleId, $activityId, $quizId);
     }
@@ -73,11 +73,11 @@ class ApiController extends YesWikiController
     {
         $output = '<h2>Extension LMS</h2>';
 
-        $urlGetQuizResultsForAUserAndAQuizz = $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
-        $fullUrlGetQuizResultsForAUserAndAQuizz = $this->wiki->Href('lms/users/TestUser/quizresults/test-course/test-module/test-activity/test-id', 'api');
+        $urlGetQuizResultsForAUserAndAQuiz = $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
+        $fullUrlGetQuizResultsForAUserAndAQuiz = $this->wiki->Href('lms/users/TestUser/quizresults/test-course/test-module/test-activity/test-id', 'api');
 
         $output .= 'The following code :<br />';
-        $output .= 'GET <a href="'. $fullUrlGetQuizResultsForAUserAndAQuizz .'"><code>'.$urlGetQuizResultsForAUserAndAQuizz.'</code></a><br />';
+        $output .= 'GET <a href="'. $fullUrlGetQuizResultsForAUserAndAQuiz .'"><code>'.$urlGetQuizResultsForAUserAndAQuiz.'</code></a><br />';
         $output .= 'gives a json with token results for the {quizId} quiz of activity {activityId} and for user {userId}<br />';
         $output .= '<code>["'.QuizManager::STATUS_LABEL.'":'.QuizManager::STATUS_CODE_OK.' = OK/';
         $output .= QuizManager::STATUS_CODE_ERROR.' = error/'.QuizManager::STATUS_CODE_NO_RESULT.' = no results,<br />';
@@ -93,9 +93,9 @@ class ApiController extends YesWikiController
         $output .= '</code></a><br />';
         $output .= 'Same as previous but for current connected leaner<br />';
         
-        $urlSaveQuizzResult = $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
+        $urlSaveQuizResult = $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
         $output .= '<br />The following code :<br />';
-        $output .= 'POST <b><code>'.$urlSaveQuizzResult.'</code></b><br />';
+        $output .= 'POST <b><code>'.$urlSaveQuizResult.'</code></b><br />';
         $output .= 'saves data float value sent in $_POST[\'result\'] for the specified user<br />';
         $output .= 'Return:<br />';
         $output .= '<code>["'.QuizManager::STATUS_LABEL.'":'.QuizManager::STATUS_CODE_OK.' = OK/';

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace YesWiki\Lms\Controller;
+
+use Symfony\Component\Routing\Annotation\Route;
+use YesWiki\Core\ApiResponse;
+use YesWiki\Core\YesWikiController;
+use YesWiki\Lms\Service\ActivityConditionsManager;
+use YesWiki\Lms\Service\CourseManager;
+
+class ApiController extends YesWikiController
+{
+    /**
+     * Give a token for POST quiz results, can only be called if connected
+     * @Route("/api/lms/quizzes/{quizId}/token",methods={"GET"},options={"acl":{"public","+"}})
+     */
+    public function getQuizzToken($quizId)
+    {
+        return new ApiResponse(
+            ['status' => false,'token' => "1234A"]
+        );
+    }
+    
+    /**
+     * @Route("/api/lms/quizzes/{quizId}",methods={"POST"},options={"acl":{"public"}})
+     *
+     * Save quiz results for a learner with a token given by getQuizzToken in $_POST['token']
+     * and results in json in $_POST['results']
+     */
+    public function saveQuizzResult($quizId)
+    {
+        /* check $_POST */
+        if (empty($_POST['token'])||empty($_POST['results'])) {
+            return new ApiResponse(
+                ['status' => false,
+                'message' => (empty($_POST['token']) ? 'you must define $_POST[\'token\'], ':'').
+                (empty($_POST['results']) ? 'you must define $_POST[\'results\']':'')]
+            );
+        }
+
+        return new ApiResponse(
+            ['status' => false,
+            'message' => 'test for quiz '.$quizId.'__token :'.$_POST['token'] ]
+        );
+    }
+
+    /**
+     * Display lms api documentation
+     *
+     * @return string
+     */
+    public function getDocumentation()
+    {
+        $output = '<h2>Extension LMS</h2>';
+
+        $urlGetQuizzToken = $this->wiki->Href('lms/quizzes/{quizId}/token', 'api');
+        $fullUrlGetQuizzToken = $this->wiki->Href('lms/quizzes/my-quizz/token', 'api');
+        $urlSaveQuizzResult = $this->wiki->Href('lms/quizzes/{quizId}', 'api');
+
+        $output .= 'The following code :<br />';
+        $output .= 'GET <a href="'. $fullUrlGetQuizzToken .'"><code>'.$urlGetQuizzToken.'</code></a><br />';
+        $output .= 'gives a json with token needed for <code>'.$urlSaveQuizzResult.'</code><br />';
+        $output .= '<code>["status":true/false,<br />';
+        $output .= '"token":"66HF867FHHF9JH"]</code><br />';
+        $output .= '<b>You must sent cookies to be connected as learner.</b><br />';
+
+        $output .= '<br />The following code :<br />';
+        $output .= 'POST <b><code>'.$urlSaveQuizzResult.'</code></b><br />';
+        $output .= 'saves data sent in json in $_POST[\'results\'] with token in $_POST[\'token\']<br />';
+        $output .= 'Token obtains with <code>'.$urlGetQuizzToken.'</code><br />';
+        $output .= 'Return:<br />';
+        $output .= '<code>["status":true/false,<br />';
+        $output .= '"message":"error message"]</code><br />';
+        return $output;
+    }
+}

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -11,7 +11,7 @@ class ApiController extends YesWikiController
 {
     
     /**
-     * Get quizz's results for a user, course,module, activity and quizId
+     * Get quiz's results for a user, course, module, activity and quizId
      * @Route("/api/lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}",methods={"GET"},options={"acl":{"public","+"}})
      */
     public function getQuizResultsForAUserAndAQuizz($userId, $courseId, $moduleId, $activityId, $quizId)
@@ -23,26 +23,36 @@ class ApiController extends YesWikiController
     }
     
     /**
-     * @Route("/api/lms/{course}/{module}/{activity}/quiz",methods={"POST"},options={"acl":{"public"}})
+     * save quiz's result for a user, course, module, activity and quizId
+     * @Route("/api/lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}",methods={"POST"},options={"acl":{"public","+"}})
      *
-     * Save quiz results for a learner with a token given by getQuizzToken in $_POST['token']
-     * and results in json in $_POST['results']
+     * Save quiz result for a learner with result as percent in float in $_POST['result']
      */
-    public function saveQuizzResult($course, $module, $activity)
+    public function saveQuizResultForAUserAndAQuiz($userId, $courseId, $moduleId, $activityId, $quizId)
     {
         /* check $_POST */
-        if (empty($_POST['token'])||empty($_POST['results'])) {
+        if (empty($_POST[QuizManager::RESULT_LABEL])) {
             return new ApiResponse(
-                ['status' => false,
-                'message' => (empty($_POST['token']) ? 'you must define $_POST[\'token\'], ':'').
-                (empty($_POST['results']) ? 'you must define $_POST[\'results\']':'')]
+                [QuizManager::STATUS_LABEL => QuizManager::STATUS_CODE_ERROR,
+                QuizManager::MESSAGE_LABEL => 'you must define $_POST[\''.QuizManager::RESULT_LABEL.'\']']
             );
         }
 
         return new ApiResponse(
-            ['status' => false,
-            'message' => 'test for quiz '.$activity.'__token :'.$_POST['token'] ]
+            $this->getService(QuizManager::class)
+                ->saveQuizResultForAUserAndAQuiz($userId, $courseId, $moduleId, $activityId, $quizId, floatval($_POST['result']))
         );
+    }
+    
+    /**
+     * save quiz's result for the connected user and for course, module, activity and quizId
+     * @Route("/api/lms/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}",methods={"POST"},options={"acl":{"public","+"}})
+     *
+     * Save quiz result for a learner with result as percent in float in $_POST['result']
+     */
+    public function saveQuizResultForAQuiz($courseId, $moduleId, $activityId, $quizId)
+    {
+        return $this->saveQuizResultForAUserAndAQuiz(null, $courseId, $moduleId, $activityId, $quizId);
     }
 
     /**
@@ -62,18 +72,21 @@ class ApiController extends YesWikiController
         $output .= 'gives a json with token results for the {quizId} quiz of activity {activityId} and for user {userId}<br />';
         $output .= '<code>["'.QuizManager::STATUS_LABEL.'":'.QuizManager::STATUS_CODE_OK.' = OK/';
         $output .= QuizManager::STATUS_CODE_ERROR.' = error/'.QuizManager::STATUS_CODE_NO_RESULT.' = no results,<br />';
-        $output .= '"'.QuizManager::RESULTS_LABEL.'":"23", // value in percent<br />';
+        $output .= '"'.QuizManager::RESULTS_LABEL.'":"[{"log_time":"2021-01-01 01:23:22","'.QuizManager::RESULT_LABEL.'":"23"}, // value in percent<br />';
+        $output .= '{"log_time":"2021-01-01 01:24:22","'.QuizManager::RESULT_LABEL.'":"32"}]", // value in percent<br />';
         $output .= '"'.QuizManager::MESSAGE_LABEL.'":"error message of needed",]</code><br />';
         $output .= '<b>You must sent cookies to be connected as learner or admin.</b><br />';
 
         
-        $urlSaveQuizzResult = $this->wiki->Href('lms/{course}/{module}/{activity}/quiz', 'api');
+        $urlSaveQuizzResult = $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
         $output .= '<br />The following code :<br />';
         $output .= 'POST <b><code>'.$urlSaveQuizzResult.'</code></b><br />';
-        $output .= 'saves data sent in json in $_POST[\'results\'] with token in $_POST[\'token\']<br />';
+        $output .= 'saves data float value sent in $_POST[\'result\'] for the specified user<br />';
         $output .= 'Return:<br />';
-        $output .= '<code>["status":true/false,<br />';
+        $output .= '<code>["'.QuizManager::STATUS_LABEL.'":'.QuizManager::STATUS_CODE_OK.' = OK/';
+        $output .= QuizManager::STATUS_CODE_ERROR.' = error,<br />';
         $output .= '"message":"error message"]</code><br />';
+        $output .= '<b>You must sent cookies to be connected as learner or admin.</b><br />';
         return $output;
     }
 }

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -9,15 +9,16 @@ use YesWiki\Lms\Service\QuizManager;
 
 class ApiController extends YesWikiController
 {
+    
     /**
-     * Give a token for POST quiz results, can only be called if connected
-     * @Route("/api/lms/{course}/{module}/{activity}/quiz/token",methods={"GET"},options={"acl":{"public","+"}})
+     * Get quizz's results for a user, course,module, activity and quizId
+     * @Route("/api/lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}",methods={"GET"},options={"acl":{"public","+"}})
      */
-    public function getQuizzToken($course, $module, $activity)
+    public function getQuizResultsForAUserAndAQuizz($userId, $courseId, $moduleId, $activityId, $quizId)
     {
         return new ApiResponse(
             $this->getService(QuizManager::class)
-                ->getQuizToken($course, $module, $activity)
+                ->getQuizResultsForAUserAndAQuizz($userId, $courseId, $moduleId, $activityId, $quizId)
         );
     }
     
@@ -53,21 +54,23 @@ class ApiController extends YesWikiController
     {
         $output = '<h2>Extension LMS</h2>';
 
-        $urlGetQuizzToken = $this->wiki->Href('lms/{course}/{module}/{activity}/quiz/token', 'api');
-        $fullUrlGetQuizzToken = $this->wiki->Href('lms/test-course/test-module/test-activity/quiz/token', 'api');
-        $urlSaveQuizzResult = $this->wiki->Href('lms/{course}/{module}/{activity}/quiz', 'api');
+        $urlGetQuizResultsForAUserAndAQuizz = $this->wiki->Href('lms/users/{userId}/quizresults/{courseId}/{moduleId}/{activityId}/{quizId}', 'api');
+        $fullUrlGetQuizResultsForAUserAndAQuizz = $this->wiki->Href('lms/users/TestUser/quizresults/test-course/test-module/test-activity/test-id', 'api');
 
         $output .= 'The following code :<br />';
-        $output .= 'GET <a href="'. $fullUrlGetQuizzToken .'"><code>'.$urlGetQuizzToken.'</code></a><br />';
-        $output .= 'gives a json with token needed for <code>'.$urlSaveQuizzResult.'</code><br />';
-        $output .= '<code>["status":true/false,<br />';
-        $output .= '"token":"66HF867FHHF9JH"]</code><br />';
-        $output .= '<b>You must sent cookies to be connected as learner.</b><br />';
+        $output .= 'GET <a href="'. $fullUrlGetQuizResultsForAUserAndAQuizz .'"><code>'.$urlGetQuizResultsForAUserAndAQuizz.'</code></a><br />';
+        $output .= 'gives a json with token results for the {quizId} quiz of activity {activityId} and for user {userId}<br />';
+        $output .= '<code>["'.QuizManager::STATUS_LABEL.'":'.QuizManager::STATUS_CODE_OK.' = OK/';
+        $output .= QuizManager::STATUS_CODE_ERROR.' = error/'.QuizManager::STATUS_CODE_NO_RESULT.' = no results,<br />';
+        $output .= '"'.QuizManager::RESULTS_LABEL.'":"23", // value in percent<br />';
+        $output .= '"'.QuizManager::MESSAGE_LABEL.'":"error message of needed",]</code><br />';
+        $output .= '<b>You must sent cookies to be connected as learner or admin.</b><br />';
 
+        
+        $urlSaveQuizzResult = $this->wiki->Href('lms/{course}/{module}/{activity}/quiz', 'api');
         $output .= '<br />The following code :<br />';
         $output .= 'POST <b><code>'.$urlSaveQuizzResult.'</code></b><br />';
         $output .= 'saves data sent in json in $_POST[\'results\'] with token in $_POST[\'token\']<br />';
-        $output .= 'Token obtains with <code>'.$urlGetQuizzToken.'</code><br />';
         $output .= 'Return:<br />';
         $output .= '<code>["status":true/false,<br />';
         $output .= '"message":"error message"]</code><br />';

--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -12,9 +12,9 @@ class ApiController extends YesWikiController
 {
     /**
      * Give a token for POST quiz results, can only be called if connected
-     * @Route("/api/lms/quizzes/{quizId}/token",methods={"GET"},options={"acl":{"public","+"}})
+     * @Route("/api/lms/{course}/{module}/{activity}/quiz/token",methods={"GET"},options={"acl":{"public","+"}})
      */
-    public function getQuizzToken($quizId)
+    public function getQuizzToken($course, $module, $activity)
     {
         return new ApiResponse(
             ['status' => false,'token' => "1234A"]
@@ -22,12 +22,12 @@ class ApiController extends YesWikiController
     }
     
     /**
-     * @Route("/api/lms/quizzes/{quizId}",methods={"POST"},options={"acl":{"public"}})
+     * @Route("/api/lms/{course}/{module}/{activity}/quiz",methods={"POST"},options={"acl":{"public"}})
      *
      * Save quiz results for a learner with a token given by getQuizzToken in $_POST['token']
      * and results in json in $_POST['results']
      */
-    public function saveQuizzResult($quizId)
+    public function saveQuizzResult($course, $module, $activity)
     {
         /* check $_POST */
         if (empty($_POST['token'])||empty($_POST['results'])) {
@@ -40,7 +40,7 @@ class ApiController extends YesWikiController
 
         return new ApiResponse(
             ['status' => false,
-            'message' => 'test for quiz '.$quizId.'__token :'.$_POST['token'] ]
+            'message' => 'test for quiz '.$activity.'__token :'.$_POST['token'] ]
         );
     }
 
@@ -53,9 +53,9 @@ class ApiController extends YesWikiController
     {
         $output = '<h2>Extension LMS</h2>';
 
-        $urlGetQuizzToken = $this->wiki->Href('lms/quizzes/{quizId}/token', 'api');
-        $fullUrlGetQuizzToken = $this->wiki->Href('lms/quizzes/my-quizz/token', 'api');
-        $urlSaveQuizzResult = $this->wiki->Href('lms/quizzes/{quizId}', 'api');
+        $urlGetQuizzToken = $this->wiki->Href('lms/{course}/{module}/{activity}/quiz/token', 'api');
+        $fullUrlGetQuizzToken = $this->wiki->Href('lms/test-course/test-module/test-activity/quiz/token', 'api');
+        $urlSaveQuizzResult = $this->wiki->Href('lms/{course}/{module}/{activity}/quiz', 'api');
 
         $output .= 'The following code :<br />';
         $output .= 'GET <a href="'. $fullUrlGetQuizzToken .'"><code>'.$urlGetQuizzToken.'</code></a><br />';

--- a/services/QuizManager.php
+++ b/services/QuizManager.php
@@ -56,7 +56,7 @@ class QuizManager
 
     /**
      * method that return an array giving results for the selected quiz
-     * @param string $userId, id of the concerned learner
+     * @param string|null $userId, id of the concerned learner, if null current learner
      * @param string $courseId, id of the concerned course
      * @param string $moduleId, id of the concerned module
      * @param string $activityId, id of the concerned activity
@@ -64,13 +64,17 @@ class QuizManager
      * @return array [self::STATUS_LABEL=>0(OK)/1(error)/2(no result),
      *      (RESULTS_LABEL=>float in %,'message'=>'error message')]
      */
-    public function getQuizResultsForAUserAndAQuizz(
-        string $userId,
+    public function getQuizResultsForAUserAndAQuiz(
+        ?string $userId = null,
         string $courseId,
         string $moduleId,
         string $activityId,
         string $quizId
     ): array {
+        if (is_null($userId)) {
+            // get current user
+            $userId = $this->learnerManager->getLearner()->getUsername();
+        }
         /* check params */
         $data = $this->checkParams($userId, $courseId, $moduleId, $activityId, $quizId);
         if ($data[self::STATUS_LABEL] == self::STATUS_CODE_ERROR) {
@@ -79,7 +83,7 @@ class QuizManager
             unset($data[self::STATUS_LABEL]);
         }
         /* find results */
-        if (empty($results = $this->findResultsForALearnerAnActivityAndAQuizz($data))) {
+        if (empty($results = $this->findResultsForALearnerAnActivityAndAQuiz($data))) {
             return [self::STATUS_LABEL => self::STATUS_CODE_NO_RESULT,
                 self::MESSAGE_LABEL => 'No results'];
         }
@@ -97,7 +101,7 @@ class QuizManager
      * @param string $quizId, id of the concerned quiz
      * @return null ['status'=>false/true,('message'=>'error message',
      *                'course'=>$course,'module'=>$module, 'activity'=>$activity,
-     *                'learner'=>$leaner,'quizzId'=>$quizzId]
+     *                'learner'=>$leaner,'quizId'=>$quizId]
      */
     private function checkParams(
         string $userId,
@@ -158,10 +162,10 @@ class QuizManager
 
     /**
      * Method that find the results for a specific user, activity and quizId, null if not existing
-     * @param array $data ['course'=>$course,'module'=>$module, 'activity'=>$activity, 'learner'=>$leaner,'quizzId'=>$quizzId]
+     * @param array $data ['course'=>$course,'module'=>$module, 'activity'=>$activity, 'learner'=>$leaner,'quizId'=>$quizId]
      * @return null|array null if no result then [{"log_time"=>...,"result"=>"10"},{"log_time"...}]
      */
-    private function findResultsForALearnerAnActivityAndAQuizz($data): ?array
+    private function findResultsForALearnerAnActivityAndAQuiz($data): ?array
     {
         $like = '%"course":"' . $data['course']->getTag() . '"%';
         $like .= '%"module":"' . $data['module']->getTag() . '"%';

--- a/services/QuizManager.php
+++ b/services/QuizManager.php
@@ -1,0 +1,113 @@
+<?php
+
+
+namespace YesWiki\Lms\Service;
+
+use YesWiki\Core\Service\TripleStore;
+use YesWiki\Wiki;
+use YesWiki\Lms\Service\CourseManager;
+use YesWiki\Lms\Service\LearnerManager;
+
+class QuizManager
+{
+    protected const LMS_TRIPLE_PROPERTY_NAME_QUIZ_TOKEN =  'https://yeswiki.net/vocabulary/lms-quiz-token' ;
+    protected const LMS_TRIPLE_PROPERTY_NAME_QUIZ_RESULT =  'https://yeswiki.net/vocabulary/lms-quiz-results' ;
+    public const STATUS_LABEL =  'status' ;
+    public const TOKEN_LABEL =  'token' ;
+    public const MESSAGE_LABEL =  'message' ;
+
+    protected $tripleStore;
+    protected $wiki;
+    protected $courseManager;
+    protected $learnerManager;
+
+    /**
+     * QuizManager constructor
+     *
+     * @param TripleStore $tripleStore the injected TripleStore instance
+     * @param Wiki $wiki
+     * @param CourseManager $courseManager
+     * @param LearnerManager $learnerManager
+     */
+    public function __construct(
+        TripleStore $tripleStore,
+        Wiki $wiki,
+        CourseManager $courseManager,
+        LearnerManager $learnerManager
+    ) {
+        $this->tripleStore = $tripleStore;
+        $this->wiki = $wiki;
+        $this->courseManager = $courseManager;
+        $this->learnerManager = $learnerManager;
+    }
+
+    /**
+     * method that return an array giving token for the selected activity
+     * @param string $courseTag, tag of the concerned course
+     * @param string $moduleTag, tag of the concerned module
+     * @param string $activityTag, tag of the concerned activity
+     * @return array ['status'=>true/false,('token'=>'token','message'=>'error message')]
+     */
+    public function getQuizToken(string $courseTag, string $moduleTag, string $activityTag): array
+    {
+        /* check params */
+        $data = $this->checkParamsForGetQuizToken($courseTag, $moduleTag, $activityTag);
+        if (!$data[self::STATUS_LABEL]) {
+            return $data;
+        } else {
+            unset($data[self::STATUS_LABEL]);
+        }
+
+        return [self::STATUS_LABEL => false,
+            self::MESSAGE_LABEL => 'api not ready'];
+    }
+
+    /**
+     * method that return an array giving values checked for the selected activity quiz
+     * @param string $courseTag, tag of the concerned course
+     * @param string $moduleTag, tag of the concerned module
+     * @param string $activityTag, tag of the concerned activity
+     * @return null ['status'=>false/true,('message'=>'error message',
+     *                'course'=>$course,'module'=>$module, 'activity'=>$activity, 'learner'=>$leaner]
+     */
+    private function checkParamsForGetQuizToken(string $courseTag, string $moduleTag, string $activityTag): array
+    {
+        if (empty($courseTag)) {
+            return [self::STATUS_LABEL => false, self::MESSAGE_LABEL => '{course} shoud not be empty !'];
+        }
+        if (!$course = $this->courseManager->getCourse($courseTag)) {
+            return [self::STATUS_LABEL => false, self::MESSAGE_LABEL => 'Not existing {course} :'.$courseTag];
+        }
+        if (empty($moduleTag)) {
+            return [self::STATUS_LABEL => false, self::MESSAGE_LABEL => '{module} shoud not be empty !'];
+        }
+        if (!$course->hasModule($moduleTag)) {
+            return [self::STATUS_LABEL => false, self::MESSAGE_LABEL => '{module} :'.$moduleTag.' is not a module of the {course} :'.$courseTag];
+        } else {
+            if (!$module = $this->courseManager->getModule($moduleTag)) {
+                return [self::STATUS_LABEL => false, self::MESSAGE_LABEL => 'Not existing {module} :'.$moduleTag];
+            }
+        }
+        if (empty($activityTag)) {
+            return [self::STATUS_LABEL => false, self::MESSAGE_LABEL => '{activity} shoud not be empty !'];
+        }
+        if (!$module->hasActivity($activityTag)) {
+            return [self::STATUS_LABEL => false, self::MESSAGE_LABEL => '{activity} :'.$activityTag.' is not an activity of the {module} :'.$moduleTag];
+        } else {
+            if (!$activity = $this->courseManager->getActivity($activityTag)) {
+                return [self::STATUS_LABEL => false, self::MESSAGE_LABEL => 'Not existing {activity} :'.$activityTag];
+            }
+        }
+        if (!$learner = $this->learnerManager->getLearner()) {
+            return [self::STATUS_LABEL => false, self::MESSAGE_LABEL => 'You should be connected as learner !'];
+        }
+
+        return [
+            self::STATUS_LABEL=>true,
+            'course'=>$course,
+            'module'=>$module,
+            'activity'=>$activity,
+            'learner'=>$learner,
+        ];
+    }
+}

--- a/services/QuizManager.php
+++ b/services/QuizManager.php
@@ -62,7 +62,7 @@ class QuizManager
      * @param string $activityId, id of the concerned activity
      * @param string $quizId, id of the concerned quiz
      * @return array [self::STATUS_LABEL=>0(OK)/1(error)/2(no result),
-     *      (RESULTS_LABEL=>float in %,'message'=>'error message')]
+     *      (self::RESULTS_LABEL=>[{"log_time"=>...,"result"=>"10"},{"log_time"...}],'message'=>'error message')]
      */
     public function getQuizResultsForAUserAndAQuiz(
         ?string $userId = null,
@@ -163,7 +163,7 @@ class QuizManager
     /**
      * Method that find the results for a specific user, activity and quizId, null if not existing
      * @param array $data ['course'=>$course,'module'=>$module, 'activity'=>$activity, 'learner'=>$leaner,'quizId'=>$quizId]
-     * @return null|array null if no result then [{"log_time"=>...,"result"=>"10"},{"log_time"...}]
+     * @return null|array null if no result otherwise [{"log_time"=>...,"result"=>"10"},{"log_time"...}]
      */
     private function findResultsForALearnerAnActivityAndAQuiz($data): ?array
     {


### PR DESCRIPTION
@mrflos voici ce que je propose pour la spec 5 pour l'api pour les quizzes.
J'ai dû faire quelques adaptations pour correspondre au format de données sur lequel nous étions d'accord pour les triples.

Je te laisse consulter la page ?api pour lire la documentation associée aux nouvelles routes lms et me dire si ça te convient pour les noms de routes et pour le format des données de retour (attention j'ai peut-être une annotation de méthode à corriger mais la doc de la page ?api est à jour.

Je pousse cette PR ce mardi matin sur doryphore pour que tu puisses l'utiliser (après validation des noms de routes et du format de stockage dans les triples).

@acheype pas d'urgence pour la relecture, tu pourras la faire en asynchrone.