### PR TITLE
Update restart button

### DIFF
--- a/controllers/CourseController.php
+++ b/controllers/CourseController.php
@@ -9,6 +9,7 @@ use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Core\YesWikiController;
 use YesWiki\Lms\Activity;
 use YesWiki\Lms\Course;
+use YesWiki\Lms\Learner;
 use YesWiki\Lms\Module;
 use YesWiki\Lms\ModuleStatus;
 use YesWiki\Lms\Service\CourseManager;
@@ -184,9 +185,8 @@ class CourseController extends YesWikiController
 
         // TODO implement getNextActivity for a learner, for the moment choose the first activity of the module
         
-        $tmpData = $this->courseManager->getLastAccessibleActivityTagAndLabelForLearner($learner, $course, $module) ;
-        $nextActivityTag = $tmpData['tag'];
-        $labelStart = $tmpData['label'];
+        list($nextActivityTag, $labelStart, $statusMsg) =
+            $this->getLastAccessibleActivityTagAndLabelForLearner($learner, $course, $module) ;
 
         if (!$disabledLink) {
             $activityLink = $this->wiki->href(
@@ -196,7 +196,6 @@ class CourseController extends YesWikiController
                 false
             );
         }
-        $statusMsg = $this->calculateModuleStatusMessage($course, $module);
 
         // End of duplicate code
 
@@ -248,6 +247,46 @@ class CourseController extends YesWikiController
                 break;
         }
     }
+
+    /**
+     * getLastAccessibleActivityTagAndLabelForLearner
+     * @param Learner|null $learner
+     * @param Course $course
+     * @param Module $module
+     * @return array ["activity's tag",'label','statusMsg']
+     */
+    public function getLastAccessibleActivityTagAndLabelForLearner(?Learner $learner = null, Course $course, Module $module): array
+    {
+        if ($learner) {
+            $nextActivityTag = $this->courseManager->getLastAccessibleActivityTagForLearner($learner, $course, $module) ;
+            $isFinished = (
+                $module->getLastActivityTag() == $nextActivityTag
+                && $learner->hasFinishedModule($course, $module)
+            );
+        }
+        $labelStart = $learner && $learner->isAdmin() && $module->getStatus($course) != ModuleStatus::OPEN ?
+            _t('LMS_BEGIN_ONLY_ADMIN')
+            : (!$learner || (is_null($nextActivityTag)) ?  _t('LMS_BEGIN')
+                : ($isFinished ? _t('LMS_RESTART') : _t('LMS_RESUME')));
+
+        if (!$learner || $isFinished || is_null($nextActivityTag)) {
+            $nextActivityTag = $module->getFirstActivityTag();
+        }
+                        
+        if ($module->getStatus($course) == ModuleStatus::OPEN && !$module->isAccessibleBy($learner, $course)) {
+            // define status here because it depends of learner and can not be stored into $module->status
+            $statusMsg = _t('LMS_MODULE_NOT_ACCESSIBLE');
+        } else {
+            $statusMsg = $this->calculateModuleStatusMessage($course, $module);
+        }
+        
+        return [
+            $nextActivityTag,
+            $labelStart,
+            $statusMsg
+        ];
+    }
+
 
     /**
      * check if we can display activity without contextual course or module

--- a/services/CourseManager.php
+++ b/services/CourseManager.php
@@ -136,7 +136,7 @@ class CourseManager
                 break;
             }
         }
-        return isset($lastOpenedActivity) ? $lastOpenedActivity->getTag() : $module->getFirstActivityTag() ;
+        return isset($lastOpenedActivity) ? $lastOpenedActivity->getTag() : null ;
     }
 
     /**
@@ -157,9 +157,9 @@ class CourseManager
         }
         $labelStart = $learner && $learner->isAdmin() && $module->getStatus($course) != ModuleStatus::OPEN ?
             _t('LMS_BEGIN_ONLY_ADMIN')
-            : (!$learner || ($module->getFirstActivityTag() == $nextActivityTag) ?  _t('LMS_BEGIN')
+            : (!$learner || (is_null($nextActivityTag)) ?  _t('LMS_BEGIN')
                 : ($isFinished ? _t('LMS_RESTART') : _t('LMS_RESUME')));
-        if (!$learner || $isFinished) {
+        if (!$learner || $isFinished || is_null($nextActivityTag)) {
             $nextActivityTag = $module->getFirstActivityTag();
         }
         return [

--- a/services/CourseManager.php
+++ b/services/CourseManager.php
@@ -138,36 +138,6 @@ class CourseManager
         }
         return isset($lastOpenedActivity) ? $lastOpenedActivity->getTag() : null ;
     }
-
-    /**
-     * getLastAccessibleActivityTagAndLabelForLearner
-     * @param Learner|null $learner
-     * @param Course $course
-     * @param Module $module
-     * @return array ['tag' => "activity's tag",'label' => 'label']
-     */
-    public function getLastAccessibleActivityTagAndLabelForLearner(?Learner $learner = null, Course $course, Module $module): array
-    {
-        if ($learner) {
-            $nextActivityTag = $this->getLastAccessibleActivityTagForLearner($learner, $course, $module) ;
-            $isFinished = (
-                $module->getLastActivityTag() == $nextActivityTag
-                && $learner->hasFinishedModule($course, $module)
-            );
-        }
-        $labelStart = $learner && $learner->isAdmin() && $module->getStatus($course) != ModuleStatus::OPEN ?
-            _t('LMS_BEGIN_ONLY_ADMIN')
-            : (!$learner || (is_null($nextActivityTag)) ?  _t('LMS_BEGIN')
-                : ($isFinished ? _t('LMS_RESTART') : _t('LMS_RESUME')));
-        if (!$learner || $isFinished || is_null($nextActivityTag)) {
-            $nextActivityTag = $module->getFirstActivityTag();
-        }
-        return [
-            'tag' => $nextActivityTag,
-            'label' => $labelStart
-        ];
-    }
-
     
     /**
      * getActivityParents


### PR DESCRIPTION
@acheype je te propose ceci pour factoriser le code pour établir le label, le status et le nom de la prochaine activité pour les modules.
Est-ce que ça résout le souci que tu avais identifié ?

**Ce que ça fait**:
 - déplace la méthode `getLastAccessibleActivityTagAndLabelForLearner` de CourseManager vers CourseController
 - factorise le code de ModuleNavigationField et de CourseController dans `getLastAccessibleActivityTagAndLabelForLearner`
 - définit le bouton à `reprendre` quand la première activité a déjà été ouverte (auparavant c'était `commencer`)

**Ce que ça ne fait pas**:
- réparer le souci de status quand la date de démarrage n'est pas fixée pour un module (car ça concerne Module->getStatus qui n'a pas été modifiée)