### PR TITLE
Fix/phph 84

### DIFF
--- a/fields/ExtraActivityField.php
+++ b/fields/ExtraActivityField.php
@@ -27,7 +27,7 @@ class ExtraActivityField extends BazarField
     {
         parent::__construct($values, $services);
 
-        
+
         $this->label = null;
         $this->default = [];
 
@@ -47,7 +47,7 @@ class ExtraActivityField extends BazarField
             if ($extraActivityLog = $this->extraActivityManager->getExtraActivityLog($value)) {
                 $courseTag = $extraActivityLog->getCourse()->getTag();
                 $module = $extraActivityLog->getModule() ;
-                
+
                 $learner = $this->learnerManager->getLearner();
                 if ($learner && $learner->isAdmin()) {
                     $learners = [] ;
@@ -59,11 +59,11 @@ class ExtraActivityField extends BazarField
                 }
             }
         }
-        
+
         return ($extraActivityLog) ? $this->render("@lms/fields/extra-activity.twig", [
             'extraActivityLog' => $extraActivityLog ,
             'learners' => $learners ?? null,
-        ]):null;
+        ]) : null;
     }
 
     protected function renderInput($entry)
@@ -129,16 +129,16 @@ class ExtraActivityField extends BazarField
             foreach (['bf_date_debut_evenement','bf_date_debut_evenement_allday','bf_date_debut_evenement_hour','bf_date_debut_evenement_minutes',
                 'bf_date_fin_evenement','bf_date_fin_evenement_allday','bf_date_fin_evenement_hour','bf_date_fin_evenement_minutes',
                 'course','module','registeredLearnerNames','tag'] as $key) {
-                $data[$key] =  $entry[$id.'_'.$key]  ?? null;
+                $data[$key] =  $entry[$id . '_' . $key]  ?? null;
             }
-            
+
             if ($this->extraActivityManager->saveExtraActivity($data)) {
                 $value = $this->getExtraActivityTagFromrelatedLink($data['course'], $data['module'], $data['relatedLink']);
             }
         } else {
             $value = $this->getValue($entry);
         }
-        return ((isset($value)) ? [$this->getPropertyName() => $value]:[])
+        return ((isset($value)) ? [$this->getPropertyName() => $value] : [])
             + ['fields-to-remove' => [$this->getPropertyName()]];
     }
 
@@ -159,7 +159,7 @@ class ExtraActivityField extends BazarField
                 }
             }
         }
-        
+
         return $extraActivityTag ?? null;
     }
 }

--- a/fields/ExtraActivityField.php
+++ b/fields/ExtraActivityField.php
@@ -149,7 +149,7 @@ class ExtraActivityField extends BazarField
      * @param string $tag of the related entry, saved in the relatedLink
      * @return string|null tag of the extra-activity
      */
-    private function getExtraActivityTagFromrelatedLink(string $courseTag, string $moduleTag = null, string $tag): ?string
+    private function getExtraActivityTagFromrelatedLink(string $courseTag, ?string $moduleTag = null, string $tag): ?string
     {
         if ($course = $this->courseManager->getCourse($courseTag)) {
             $module = ($moduleTag) ? $course->getModule($moduleTag) : null;

--- a/fields/ExtraActivityField.php
+++ b/fields/ExtraActivityField.php
@@ -149,7 +149,7 @@ class ExtraActivityField extends BazarField
      * @param string $tag of the related entry, saved in the relatedLink
      * @return string|null tag of the extra-activity
      */
-    private function getExtraActivityTagFromrelatedLink(string $courseTag, ?string $moduleTag = null, string $tag): ?string
+    private function getExtraActivityTagFromrelatedLink(string $courseTag, ?string $moduleTag = null, string $tag = ""): ?string
     {
         if ($course = $this->courseManager->getCourse($courseTag)) {
             $module = ($moduleTag) ? $course->getModule($moduleTag) : null;

--- a/libs/CourseStructure.php
+++ b/libs/CourseStructure.php
@@ -92,7 +92,7 @@ abstract class CourseStructure
         return $this->getField('bf_titre');
     }
 
-    
+
     /**
      * Get the Extra-activities of the courseStructure
      *
@@ -103,7 +103,7 @@ abstract class CourseStructure
         return $this->extraActivityLogs;
     }
 
-    
+
     /**
      * Set the Extra-activities of the courseStructure
      *

--- a/libs/CourseStructure.php
+++ b/libs/CourseStructure.php
@@ -34,7 +34,7 @@ abstract class CourseStructure
         EntryManager $entryManager,
         DateManager $dateManager,
         string $objectTag,
-        array $objectFields = null
+        ?array $objectFields = null
     ) {
         $this->tag = $objectTag;
 

--- a/libs/ExtraActivityLog.php
+++ b/libs/ExtraActivityLog.php
@@ -70,7 +70,7 @@ class ExtraActivityLog implements \JsonSerializable
             && !empty($data['date'])
             && !empty($data['elapsedTime'])
             && !empty($data['course'])
-            ) {
+        ) {
             return new ExtraActivityLog(
                 $dateManager,
                 $data['tag'],
@@ -79,7 +79,7 @@ class ExtraActivityLog implements \JsonSerializable
                 $dateManager->createDatetimeFromString($data['date']),
                 $dateManager->createIntervalFromString($data['elapsedTime']),
                 $courseManager->getCourse($data['course']),
-                !empty($data['module']) ? $courseManager->getModule($data['module']):null,
+                !empty($data['module']) ? $courseManager->getModule($data['module']) : null,
             )  ;
         } else {
             return null;

--- a/libs/ExtraActivityLog.php
+++ b/libs/ExtraActivityLog.php
@@ -39,7 +39,7 @@ class ExtraActivityLog implements \JsonSerializable
         Carbon $date,
         CarbonInterval $elapsedTime,
         Course $course,
-        Module $module = null
+        ?Module $module = null
     ) {
         $this->dateManager = $dateManager;
         $this->tag = $tag;

--- a/libs/Learner.php
+++ b/libs/Learner.php
@@ -207,7 +207,7 @@ class Learner
      * @param null|Activity $activity
      * @return bool
      */
-    public function hasOpened(Course $course, Module $module, Activity $activity = null): bool
+    public function hasOpened(Course $course, Module $module, ?Activity $activity = null): bool
     {
         $progress = $this->getProgresses()->getProgressForActivityOrModuleForLearner(
             $this,

--- a/libs/Learner.php
+++ b/libs/Learner.php
@@ -209,8 +209,12 @@ class Learner
      */
     public function hasOpened(Course $course, Module $module, Activity $activity = null): bool
     {
-        $progress = $this->getProgresses()->getProgressForActivityOrModuleForLearner($this, $course, $module,
-            $activity);
+        $progress = $this->getProgresses()->getProgressForActivityOrModuleForLearner(
+            $this,
+            $course,
+            $module,
+            $activity
+        );
         return !empty($progress);
     }
 

--- a/services/CourseManager.php
+++ b/services/CourseManager.php
@@ -139,13 +139,13 @@ class CourseManager
         }
         return isset($lastOpenedActivity) ? $lastOpenedActivity->getTag() : null ;
     }
-    
+
     /**
      * getActivityParents
      * @param array $entry
      * @return array [['course'=>courseTag],['module'=>moduleTag],['course'=>courseTag,'module'=>moduleTag]]
      */
-    public function getActivityParents(array $entry):array
+    public function getActivityParents(array $entry): array
     {
         if (!isset($entry['id_fiche'])) {
             return [];
@@ -157,18 +157,18 @@ class CourseManager
             foreach ($course->getModules() as $module) {
                 if ($module->hasActivity($entry['id_fiche'])) {
                     if (!$courseFound) {
-                        $parents[] = ['course'=>$course->getTag()];
+                        $parents[] = ['course' => $course->getTag()];
                     }
                     $courseFound = true;
-                    $parents[] = ['course'=>$course->getTag(),'module'=>$module->getTag()];
-                    $parents[] = ['module'=>$module->getTag()];
+                    $parents[] = ['course' => $course->getTag(),'module' => $module->getTag()];
+                    $parents[] = ['module' => $module->getTag()];
                 }
             }
         }
         return $parents;
     }
 
-    
+
     /** getNextActivityOrModule
      * @param Course $course
      * @param Module $module

--- a/services/CourseManager.php
+++ b/services/CourseManager.php
@@ -53,7 +53,7 @@ class CourseManager
      * @param array|null $activityFields the activity fields if needed to populate directly the object
      * @return Activity|null the activity or null if the entry is not an activity
      */
-    public function getActivity(string $entryTag, array $activityFields = null): ?Activity
+    public function getActivity(string $entryTag, ?array $activityFields = null): ?Activity
     {
         $activityEntry = $this->entryManager->getOne($entryTag);
         if ($activityEntry && intval($activityEntry['id_typeannonce']) == $this->activityFormId) {
@@ -69,7 +69,7 @@ class CourseManager
      * @param array|null $moduleFields the module fields if needed to populate directly the object
      * @return Module|null the module or null if the entry is not a module
      */
-    public function getModule(string $entryTag, array $moduleFields = null): ?Module
+    public function getModule(string $entryTag, ?array $moduleFields = null): ?Module
     {
         $moduleEntry = $this->entryManager->getOne($entryTag);
         if ($moduleEntry && intval($moduleEntry['id_typeannonce']) == $this->moduleFormId) {
@@ -85,7 +85,7 @@ class CourseManager
      * @param array|null $courseFields the course fields if needed to populate directly the object
      * @return Module|null the course or null if the entry is not a course
      */
-    public function getCourse(string $entryTag, array $courseFields = null): ?Course
+    public function getCourse(string $entryTag, ?array $courseFields = null): ?Course
     {
         $courseEntry = $this->entryManager->getOne($entryTag);
         if ($courseEntry && intval($courseEntry['id_typeannonce']) == $this->courseFormId) {

--- a/services/ExtraActivityManager.php
+++ b/services/ExtraActivityManager.php
@@ -162,7 +162,7 @@ class ExtraActivityManager
      * @param Learner @learner (optional)
      * @return ExtraActivityLogs the courseStructure's extraActivityLogs
      */
-    public function getExtraActivityLogs(Course $course, Module $module = null, Learner $learner = null): ExtraActivityLogs
+    public function getExtraActivityLogs(Course $course, ?Module $module = null, ?Learner $learner = null): ExtraActivityLogs
     {
         $like = '%"course":"' . $course->getTag() . '"';
         if (!is_null($module)) {

--- a/services/ExtraActivityManager.php
+++ b/services/ExtraActivityManager.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace YesWiki\Lms\Service;
 
 use Carbon\Carbon;
@@ -57,7 +56,7 @@ class ExtraActivityManager
                 || empty($data['bf_date_fin_evenement'])
                 || empty($data['course'])
                 || empty($data['registeredLearnerNames'])) {
-            $output = 'Errors in '. get_class($this) . ' :<br>' ;
+            $output = 'Errors in ' . get_class($this) . ' :<br>' ;
             $output .= (empty($data['title'])) ? 'empty($data[\'title\'])<br>' : '' ;
             $output .= (empty($data['bf_date_debut_evenement'])) ? 'empty($data[\'bf_date_debut_evenement\'])<br>' : '' ;
             $output .= (empty($data['bf_date_fin_evenement'])) ? 'empty($data[\'bf_date_fin_evenement\'])<br>' : '' ;
@@ -72,12 +71,12 @@ class ExtraActivityManager
         if (!empty($data['tag'])) {
             $extraActivityLogs = $this->getExtraActivityLogsFromLike('%"tag":"' . $data['tag'] . '"%');
             if (!$extraActivityLogs->has($data['tag'])) {
-                throw new \Exception('Errors in '. get_class($this) . ' : $data[\'tag\'] defined but not existing in triples' .'<br>');
+                throw new \Exception('Errors in ' . get_class($this) . ' : $data[\'tag\'] defined but not existing in triples' . '<br>');
             }
         } else {
             // define new Tag
             $tmptag = genere_nom_wiki($data['title'], 1);
-        
+
             // check if tag is a pageName or already exists for this course
             // get all extra-activities
             $extraActivityLogs = $this->getExtraActivityLogsFromLike('');
@@ -88,7 +87,7 @@ class ExtraActivityManager
                 ++$i;
             } while ($i < 1000 && $extraActivityLogs->has($tag)) ;
             if ($extraActivityLogs->has($tag)) {
-                throw new \Exception('Errors in '. get_class($this) . ' : genere_nom_wiki does not work' .'<br>');
+                throw new \Exception('Errors in ' . get_class($this) . ' : genere_nom_wiki does not work' . '<br>');
             } else {
                 $data['tag'] = $tag ;
             }
@@ -100,8 +99,8 @@ class ExtraActivityManager
         $module = !empty($data['module']) ? $this->courseManager->getModule($data['module']) : null;
 
         // Date
-        $date=$this->getDateFromData('bf_date_debut_evenement', $data);
-        $endDate=$this->getDateFromData('bf_date_fin_evenement', $data);
+        $date = $this->getDateFromData('bf_date_debut_evenement', $data);
+        $endDate = $this->getDateFromData('bf_date_fin_evenement', $data);
         if (isset($data['bf_date_fin_evenement_allday']) && $data['bf_date_fin_evenement_allday'] == 1) {
             $endDate->add(1, 'days') ;
         }
@@ -121,10 +120,10 @@ class ExtraActivityManager
 
         // === START remove previous data if existing ====
         if ($this->getExtraActivityLog($data['tag']) && !$this->deleteExtraActivity($data['tag'])) {
-            throw new \Exception('Errors in '. get_class($this) . ' when deleting '.$data['tag'].'<br>');
+            throw new \Exception('Errors in ' . get_class($this) . ' when deleting ' . $data['tag'] . '<br>');
         }
         // === END remove previous data ====
-    
+
         // === START save new data ====
         $errorMessage = '' ;
         foreach ($data['registeredLearnerNames'] as $learnerName => $value) {
@@ -135,13 +134,13 @@ class ExtraActivityManager
                 '',
                 ''
             ) > 0))) {// create
-                $errorMessage .= 'Errors in '. get_class($this) . ' when creating '.$data['tag'].' for '.$learnerName .'<br>';
+                $errorMessage .= 'Errors in ' . get_class($this) . ' when creating ' . $data['tag'] . ' for ' . $learnerName . '<br>';
             }
         }
         if (!empty($errorMessage)) {
             throw new \Exception($errorMessage);
         }
-        
+
         // === END save new data ====
         return true;
     }
@@ -149,9 +148,9 @@ class ExtraActivityManager
     private function getDateFromData(string $prefix, array $data): ?Carbon
     {
         $date = $data[$prefix];
-        if (isset($data[$prefix.'_allday']) && $data[$prefix.'_allday'] == 0) {
-            $date .= ' ' . ($data[$prefix.'_hour'] ?? '00'). ':' ;
-            $date .=  ($data[$prefix.'_minutes'] ?? '00'). ':00' ;
+        if (isset($data[$prefix . '_allday']) && $data[$prefix . '_allday'] == 0) {
+            $date .= ' ' . ($data[$prefix . '_hour'] ?? '00') . ':' ;
+            $date .=  ($data[$prefix . '_minutes'] ?? '00') . ':00' ;
         }
         return new Carbon($date) ;
     }
@@ -171,7 +170,7 @@ class ExtraActivityManager
         } else {
             $like .= '}%';
         }
-        return $this->getExtraActivityLogsFromLike($like, ($learner)?$learner->getUsername():'') ;
+        return $this->getExtraActivityLogsFromLike($like, ($learner) ? $learner->getUsername() : '') ;
     }
 
     /**
@@ -195,7 +194,7 @@ class ExtraActivityManager
      * @param string $learnerName
      * @return ExtraActivityLogs the courseStructure's extraActivityLogs
      */
-    private function getExtraActivityLogsFromLike(string $like, string $learnerName = ''):ExtraActivityLogs
+    private function getExtraActivityLogsFromLike(string $like, string $learnerName = ''): ExtraActivityLogs
     {
         $results = $this->tripleStore->getMatching(
             (empty($learnerName) ? null : $learnerName),
@@ -226,7 +225,7 @@ class ExtraActivityManager
         return $extraActivityLogs ;
     }
 
-    
+
     /**
      * delete the Extra-activities of a courseStructure
      * @param string $tag tag of the ExtraActivityLog
@@ -246,7 +245,7 @@ class ExtraActivityManager
         );
 
         if (!$results) {
-            throw new \Exception('Errors in '. get_class($this) . ' : not possible to delete tag : "'.$tag.'" because not existing <br>');
+            throw new \Exception('Errors in ' . get_class($this) . ' : not possible to delete tag : "' . $tag . '" because not existing <br>');
         }
 
         $errorMessage = '';
@@ -259,7 +258,7 @@ class ExtraActivityManager
                 ''
             ) != 0) {
                 // error but continue deleting others before throwing error
-                $errorMessage .= 'Errors in '. get_class($this) . ' : error when deleting tag : "'.$tag.'" in TripleStore<br>'  ;
+                $errorMessage .= 'Errors in ' . get_class($this) . ' : error when deleting tag : "' . $tag . '" in TripleStore<br>'  ;
             };
         }
         if (!empty($errorMessage)) {

--- a/services/LearnerManager.php
+++ b/services/LearnerManager.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace YesWiki\Lms\Service;
 
 use Carbon\Carbon;
@@ -61,7 +60,7 @@ class LearnerManager
     {
         // load ConditionsChecker not in constructor to prevent loop
         $conditionsChecker = $this->wiki->services->get(ConditionsChecker::class);
-        if (empty($username)){
+        if (empty($username)) {
             $user = $this->userManager->getLoggedUser();
             return empty($user) ?
                 null

--- a/services/LearnerManager.php
+++ b/services/LearnerManager.php
@@ -56,7 +56,7 @@ class LearnerManager
      * @param string $username the username for a specific learner
      * @return Learner|null the Learner or null if not connected or not existing
      */
-    public function getLearner(string $username = null): ?Learner
+    public function getLearner(?string $username = null): ?Learner
     {
         // load ConditionsChecker not in constructor to prevent loop
         $conditionsChecker = $this->wiki->services->get(ConditionsChecker::class);


### PR DESCRIPTION
Raison : https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter

Attention, 2 commits :
- le premier pour de l'autoformat
- le second, **le plus important**, pour l'ajout des `?` nécessaires